### PR TITLE
Use a Pipenv to manage dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+Pipfile.lock

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyqt6 = "*"
+requests = "*"
+python-dateutil = "*"
+cryptography = "*"
+pyqtgraph = "*"
+
+[dev-packages]
+pyinstaller = "*"
+
+[requires]
+python_version = "3"


### PR DESCRIPTION
This allows anyone to run `pipenv install` and does not interfere with package managers or other pip dependencies.
The traditional `pip install -r requirements.txt` stays available but pypa.io seems to be moving away from package installation without a virtual python environment.