### PR TITLE
Remove all dependencies on Qt from the API module

### DIFF
--- a/src/LiveboxMonitor/__main__.py
+++ b/src/LiveboxMonitor/__main__.py
@@ -22,6 +22,7 @@ from LiveboxMonitor.tabs import (LmDeviceListTab, LmInfoTab, LmGraphTab, LmDevic
 from LiveboxMonitor.dlg.LmLiveboxCnx import LiveboxCnxDialog
 from LiveboxMonitor.dlg.LmLiveboxSignin import LiveboxSigninDialog
 from LiveboxMonitor.lang.LmLanguages import LANGUAGES_LOCALE, get_main_label as lx, get_main_message as mx
+from LiveboxMonitor.util import LmUtils
 
 from LiveboxMonitor.__init__ import __version__
 
@@ -80,7 +81,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
         QtCore.QCoreApplication.processEvents()
         if self.signin():
             if not self._api._intf.build_list():
-                LmTools.error("Failed to build interface list.")
+                LmUtils.error("Failed to build interface list.")
             self.adjust_to_livebox_model()
             self.init_ui()
             self.setWindowTitle(self.app_window_title())
@@ -302,7 +303,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
             try:
                 r = session.signin(LmConf.LiveboxUser, LmConf.LiveboxPassword, not LmConf.SavePasswords)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 r = -1
             finally:
                 self._task.end()
@@ -317,7 +318,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
                 if dialog.exec():
                     url = dialog.get_url()
                     # Remove unwanted characters (can be set via Paste action) + cleanup
-                    url = LmTools.clean_url(re.sub("[\n\t]", "", url))
+                    url = LmUtils.clean_url(re.sub("[\n\t]", "", url))
                     LmConf.set_livebox_url(url)
                     self.show()
                     continue
@@ -354,7 +355,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
     def adjust_to_livebox_model(self):
         LmConf.set_livebox_mac(self._api._info.get_mac())
 
-        LmTools.log_debug(1, f"Identified Livebox model: {self._api._info.get_model_name()} ([{self._api._info.get_model()}] {self._api._info.get_raw_model_name()})")
+        LmUtils.log_debug(1, f"Identified Livebox model: {self._api._info.get_model_name()} ([{self._api._info.get_model()}] {self._api._info.get_raw_model_name()})")
 
         self.determine_fiber_link()
         self.determine_livebox_pro()
@@ -367,7 +368,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
         try:
             d = self._api._info.get_wan_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._link_type = "UNKNOWN"
         else:
             self._link_type = d.get("LinkType", "UNKNOWN").upper()
@@ -382,8 +383,8 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
             # Check link type for Livebox 4
             self._fiber_link = (self._link_type == "SFP")
 
-        LmTools.log_debug(1, f"Identified link type: {self._link_type}")
-        LmTools.log_debug(1, f"Identified fiber link: {self._fiber_link}")
+        LmUtils.log_debug(1, f"Identified link type: {self._link_type}")
+        LmUtils.log_debug(1, f"Identified fiber link: {self._fiber_link}")
 
 
     ### Determine if Pro or Residential subscription
@@ -391,17 +392,17 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
         try:
             d = self._api._info.get_connection_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._livebox_pro = False
         else:
             offer_type = d.get("OfferType")
             if offer_type is None:
-                LmTools.error("Missing offer type in NMC:get, cannot determine Livebox Pro model")
+                LmUtils.error("Missing offer type in NMC:get, cannot determine Livebox Pro model")
                 self._livebox_pro = False
             else:
                 self._livebox_pro = "PRO" in offer_type.upper()
 
-        LmTools.log_debug(1, f"Identified Livebox Pro: {self._livebox_pro}")
+        LmUtils.log_debug(1, f"Identified Livebox Pro: {self._livebox_pro}")
 
 
     ### Exit with escape
@@ -419,7 +420,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
 
     # Display an error popup
     def display_error(self, error_msg, silent=False):
-        LmTools.error(error_msg.rstrip())
+        LmUtils.error(error_msg.rstrip())
 
         if not silent:
             self._task.suspend()
@@ -504,7 +505,7 @@ class LiveboxMonitorUI(QtWidgets.QMainWindow, LmDeviceListTab.LmDeviceList,
 
 # ### wakepy error handler
 def wake_py_failure(result):
-    LmTools.error(f"Failed to keep system awake mode={result.mode_name} active={result.active_method} success={result.success} err={result.get_failure_text()}")
+    LmUtils.error(f"Failed to keep system awake mode={result.mode_name} active={result.active_method} success={result.success} err={result.get_failure_text()}")
 
 
 # ### Fatal error handler
@@ -554,7 +555,7 @@ def main(native_run=False):
             try:
                 locale.setlocale(locale.LC_ALL, (LANGUAGES_LOCALE[LmConf.Language], "UTF-8"))
             except Exception as e:
-                LmTools.error(f"setlocale() error: {e}")
+                LmUtils.error(f"setlocale() error: {e}")
 
             # Set Qt language to selected preference
             translator = QtCore.QTranslator()

--- a/src/LiveboxMonitor/api/LmApi.py
+++ b/src/LiveboxMonitor/api/LmApi.py
@@ -5,7 +5,7 @@ import json
 import hashlib
 import base64
 
-from LiveboxMonitor.app import LmTools
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -136,11 +136,11 @@ class LmApi:
         try:
             test_file = open(test_file_path)
             mockup = json.load(test_file)
-            LmTools.log_debug(1, f"Testing with: {test_file_path}")
+            LmUtils.log_debug(1, f"Testing with: {test_file_path}")
         except OSError:
             mockup = None    # No test file found
         except Exception as e:
-            LmTools.error(f"Wrong JSON {signature}.json: {e}")
+            LmUtils.error(f"Wrong JSON {signature}.json: {e}")
             raise LmApiException(f"{LmApi.err_str(service, method, err_str)}: bad test driver json")
         finally:
             if test_file is not None:

--- a/src/LiveboxMonitor/api/LmIntfApi.py
+++ b/src/LiveboxMonitor/api/LmIntfApi.py
@@ -1,7 +1,7 @@
 ### Livebox Monitor Interface APIs ###
 
 from LiveboxMonitor.api.LmApi import LmApi, LmApiException
-from LiveboxMonitor.app import LmTools
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -106,7 +106,7 @@ class IntfApi(LmApi):
     def get_list(self):
         if self._list is None:
             if not self._api._intf.build_list():
-                LmTools.error("Failed to build interface list.")
+                LmUtils.error("Failed to build interface list.")
         return self._list
 
 
@@ -143,7 +143,7 @@ class IntfApi(LmApi):
         try:
             d = self.get_raw_list()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return False
 
         # Collect all interfaces per type

--- a/src/LiveboxMonitor/api/LmLiveboxInfoApi.py
+++ b/src/LiveboxMonitor/api/LmLiveboxInfoApi.py
@@ -4,7 +4,7 @@ import requests
 
 from LiveboxMonitor.api.LmApi import LmApi, LmApiException
 from LiveboxMonitor.api.LmSession import LmSession
-from LiveboxMonitor.app import LmTools
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -64,8 +64,8 @@ class LiveboxInfoApi(LmApi):
         try:
             d = self.get_device_info()
         except Exception as e:
-            LmTools.error(str(e))
-            LmTools.error("Cannot determine Livebox model.")
+            LmUtils.error(str(e))
+            LmUtils.error("Cannot determine Livebox model.")
             self._mac_addr = ""
             self._model = 0
             self._raw_model_name = ""
@@ -78,11 +78,11 @@ class LiveboxInfoApi(LmApi):
                 self._model_name = LIVEBOX_MODEL_NAME_MAP.get(model)
                 self._raw_model_name = model
             if self._model_name is None:
-                LmTools.error(f"Unknown Livebox model: {model}, defaulting to {DEFAULT_RAW_MODEL}.")
+                LmUtils.error(f"Unknown Livebox model: {model}, defaulting to {DEFAULT_RAW_MODEL}.")
                 self._model_name = LIVEBOX_MODEL_NAME_MAP.get(DEFAULT_RAW_MODEL)
             self._model = LIVEBOX_MODEL_MAP.get(self._model_name)
             if self._model is None:
-                LmTools.error(f"Incorrect internal Livebox model setup: {self._model_name} is unknown.")
+                LmUtils.error(f"Incorrect internal Livebox model setup: {self._model_name} is unknown.")
 
             self._software_version = d.get("SoftwareVersion", "")
 

--- a/src/LiveboxMonitor/api/LmWifiApi.py
+++ b/src/LiveboxMonitor/api/LmWifiApi.py
@@ -1,7 +1,7 @@
 ### Livebox Monitor Wifi APIs ###
 
 from LiveboxMonitor.api.LmApi import LmApi, LmApiException
-from LiveboxMonitor.app import LmTools
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -97,7 +97,7 @@ class WifiApi(LmApi):
             else:
                 self.disable_guest_activation_timer()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
 
 
     ### Get guest activation timer - in seconds
@@ -139,7 +139,7 @@ class WifiApi(LmApi):
         try:
             d = self.get_power_management_profiles("WiFi")
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             # If failed, try legacy method
             return self.get_scheduler_enable_legacy()
         else:
@@ -147,7 +147,7 @@ class WifiApi(LmApi):
             if d is not None:
                 return d.get("Activate")
             else:
-                LmTools.error("PowerManagement:getProfiles - No WiFi profile")
+                LmUtils.error("PowerManagement:getProfiles - No WiFi profile")
                 return self.get_scheduler_enable_legacy()
 
 
@@ -188,7 +188,7 @@ class WifiApi(LmApi):
             else:
                 self.call("PowerManagement", "setProfiles", {"profiles": [{"profile": "WiFi", "activate": False}]})
         except Exception as e:
-            LmTools.error(f"PowerManagement method failed with error={e}, trying legacy method.")
+            LmUtils.error(f"PowerManagement method failed with error={e}, trying legacy method.")
             return self.set_scheduler_enable_legacy(enable)
 
         # ID has to remain 'wl0' - it is NOT corresponding to an intf key
@@ -241,7 +241,7 @@ class WifiApi(LmApi):
                 d = self.call_raw("Scheduler", "getSchedule", {"type": "WLAN", "ID": i}, err_str=i)
             except Exception as e:
                 err_msg = str(e)
-                LmTools.error(err_msg)
+                LmUtils.error(err_msg)
                 failed = True
                 break
             status = d.get("status")
@@ -255,7 +255,7 @@ class WifiApi(LmApi):
                 schedule = d
             else:
                 err_msg = f"Scheduler:getSchedule service failed for {i} interface."
-                LmTools.error(err_msg)
+                LmUtils.error(err_msg)
                 failed = True
                 break
 
@@ -270,11 +270,11 @@ class WifiApi(LmApi):
             try:
                 d = self.call_no_check("Scheduler", "addSchedule", {"type": "WLAN", "info": p})
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 d = None
             if not d:
                 err_msg = f"Scheduler:addSchedule service failed for {i} interface.\nLivebox might reboot."
-                LmTools.error(err_msg)
+                LmUtils.error(err_msg)
                 failed = True
                 if n:   # Trigger a restore (causing a Livebox reboot) if at least one succeeded previously
                     restore = True
@@ -292,11 +292,11 @@ class WifiApi(LmApi):
                 try:
                     d = self.call_no_check("Scheduler", "enableSchedule", {"type": "WLAN", "ID": i, "enable": enable}, err_str=i)
                 except Exception as e:
-                    LmTools.error(str(e))
+                    LmUtils.error(str(e))
                     d = None
                 if not d:
                     err_msg = f"Scheduler:enableSchedule service failed for {i} interface."
-                    LmTools.error(err_msg)
+                    LmUtils.error(err_msg)
                     failed = True
 
         if failed:
@@ -354,7 +354,7 @@ class WifiApi(LmApi):
             config["Enable"] = self.get_enable()
             b, w, d = self.get_intf()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return None
 
         # Get MLO status if available
@@ -362,7 +362,7 @@ class WifiApi(LmApi):
             try:
                 config["MLO"] = self.get_mlo_enable()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 config["MLO"] = False
 
         # Get setup for each interface in wlanvap
@@ -435,7 +435,7 @@ class WifiApi(LmApi):
             try:
                 d = self._api._intf.get_info(intf_key)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
             else:
                 m = {}
                 m["Modes"] = d.get("SupportedStandards")
@@ -478,7 +478,7 @@ class WifiApi(LmApi):
             try:
                 self.set_configuration_mode(new_unique_ssid)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 status = False
 
         # Initiate parameters
@@ -540,7 +540,7 @@ class WifiApi(LmApi):
             try:
                 self.set_wlan_config(params)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 status = False
 
         # Activate/Deactivate Wifi
@@ -548,7 +548,7 @@ class WifiApi(LmApi):
             try:
                 self.set_enable(new_config["Enable"])
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 status = False             
 
         # Activate/Deactivate MLO if relevant
@@ -556,7 +556,7 @@ class WifiApi(LmApi):
             try:
                 self.set_mlo_enable(new_config["MLO"])
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 status = False             
 
         return status
@@ -571,16 +571,16 @@ class WifiApi(LmApi):
             s = self.get_guest_status()
             b, w, d = self.get_intf(True)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return None
 
         config["Enable"] = s.get("Status") == "Enabled"
 
         if s.get("ActivationTimeout", 0) != 0:
-            start_time = LmTools.livebox_timestamp(s.get("StartTime"))
-            end_time = LmTools.livebox_timestamp(s.get("ValidTime"))
+            start_time = LmUtils.livebox_timestamp(s.get("StartTime"))
+            end_time = LmUtils.livebox_timestamp(s.get("ValidTime"))
             if (start_time is None) or (end_time is None):
-                LmTools.error("Activation timeout timestamps error")
+                LmUtils.error("Activation timeout timestamps error")
                 diff = 0
             else:
                 diff = int((end_time - start_time).total_seconds())
@@ -592,7 +592,7 @@ class WifiApi(LmApi):
         try:
             config["Timer"] = self.get_guest_activation_timer()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             config["Timer"] = 0
 
         # Get setup for each interface
@@ -695,7 +695,7 @@ class WifiApi(LmApi):
             try:
                 self.set_wlan_config(params)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 status = False
 
         # Activate/Deactivate Guest Wifi or reset timer
@@ -705,7 +705,7 @@ class WifiApi(LmApi):
             elif new_config["Enable"]:
                 self.set_guest_activation_timer(new_config["Duration"] // 3600)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             status = False
 
         return status
@@ -757,7 +757,7 @@ class WifiApi(LmApi):
         try:
             d = self.get_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             d = None
         if d is None:
             u[WifiKey.ENABLE] = WifiStatus.ERROR
@@ -772,7 +772,7 @@ class WifiApi(LmApi):
             try:
                 status = self.get_scheduler_enable()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 status = None
 
             # Agregate result
@@ -791,7 +791,7 @@ class WifiApi(LmApi):
         try:
             b, w, d = self.get_intf()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             b = None
             w = None
             d = None
@@ -857,7 +857,7 @@ class WifiApi(LmApi):
             try:
                 b, w, d = self.get_intf(True)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 b = None
                 w = None
                 d = None

--- a/src/LiveboxMonitor/app/LmConfig.py
+++ b/src/LiveboxMonitor/app/LmConfig.py
@@ -20,6 +20,7 @@ from LiveboxMonitor.api.LmLiveboxInfoApi import LiveboxInfoApi
 from LiveboxMonitor.dlg.LmReleaseWarning import ReleaseWarningDialog
 from LiveboxMonitor.lang import LmLanguages
 from LiveboxMonitor.lang.LmLanguages import get_config_prefs_label as lx, get_config_message as mx
+from LiveboxMonitor.util import LmUtils
 
 from LiveboxMonitor.__init__ import __build__
 
@@ -362,7 +363,7 @@ def release_check():
         d = resp.json()
         v = d["tag_name"]
     except Exception as e:
-        LmTools.error(f"Cannot get latest release infos. Error: {e}")
+        LmUtils.error(f"Cannot get latest release infos. Error: {e}")
         return
 
     # Convert version string into hex int aligned with __build__ representation
@@ -380,7 +381,7 @@ def release_check():
     try:
         r = int(major.zfill(2) + minor.zfill(2) + patch.zfill(2), 16)
     except Exception as e:
-        LmTools.error(f"Cannot decode latest release infos. Error: {e}")
+        LmUtils.error(f"Cannot decode latest release infos. Error: {e}")
         return
 
     # Warn if this release is not the latest
@@ -459,15 +460,15 @@ class LmConf:
         config_file = None
         dirty_config = False
         config_file_path = os.path.join(LmConf.get_config_directory(), CONFIG_FILE)
-        LmTools.log_debug(1, "Reading configuration in", config_file_path)
+        LmUtils.log_debug(1, "Reading configuration in", config_file_path)
         try:
             config_file = open(config_file_path)
             config = json.load(config_file)
         except OSError:
-            LmTools.error("No configuration file, creating one.")
+            LmUtils.error("No configuration file, creating one.")
             dirty_config = True
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             if LmTools.ask_question(mx("Wrong {} file, fully reset it?", "wrongFile").format(CONFIG_FILE)):
                 dirty_config = True
             else:
@@ -547,7 +548,7 @@ class LmConf:
                     LmConf.LogLevel = 0
                 elif LmConf.LogLevel > 2:
                     LmConf.LogLevel = 2
-                LmTools.set_verbosity(LmConf.LogLevel)
+                LmUtils.set_verbosity(LmConf.LogLevel)
             p = config.get("No Release Warning")
             if p is not None:
                 LmConf.NoReleaseWarning = int(p)
@@ -614,16 +615,16 @@ class LmConf:
         hw_key = get_hardware_key()
 
         # Read file if it exists
-        LmTools.log_debug(1, "Reading key file in", key_file_path)
+        LmUtils.log_debug(1, "Reading key file in", key_file_path)
         try:
             key_file = open(key_file_path, "rb")
             key = key_file.read()
             key_file.close()
         except OSError:
-            LmTools.error("No key file, creating one.")
+            LmUtils.error("No key file, creating one.")
             key = None
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             LmTools.display_error(mx("Cannot read key file.", "keyFileErr"))
             if key_file is not None:
                 key_file.close()
@@ -633,29 +634,29 @@ class LmConf:
             try:
                 LmConf.Secret = Fernet(hw_key.encode("utf-8")).decrypt(key).decode("utf-8")
             except Exception:
-                LmTools.error("Invalid key file, recreating it.")
+                LmUtils.error("Invalid key file, recreating it.")
             else:
                 return True
 
         # Create config directory if doesn't exist
         if not os.path.isdir(config_path):
-            LmTools.log_debug(1, "Creating config directory", config_path)
+            LmUtils.log_debug(1, "Creating config directory", config_path)
             try:
                 os.makedirs(config_path)
             except Exception as e:
-                LmTools.error(f"Cannot create configuration folder. Error: {e}")
+                LmUtils.error(f"Cannot create configuration folder. Error: {e}")
                 LmTools.display_error(mx("Cannot create configuration folder.", "configFolderErr"))
                 return False
 
         # Create key file
         LmConf.Secret = Fernet.generate_key().decode()
         key = Fernet(hw_key.encode("utf-8")).encrypt(LmConf.Secret.encode("utf-8"))
-        LmTools.log_debug(1, "Creating key file", key_file_path)
+        LmUtils.log_debug(1, "Creating key file", key_file_path)
         try:
             with open(key_file_path, "wb") as key_file:
                 key_file.write(key)
         except Exception as e:
-            LmTools.error(f"Cannot save key file. Error: {e}")
+            LmUtils.error(f"Cannot save key file. Error: {e}")
 
         return True
 
@@ -759,7 +760,7 @@ class LmConf:
     ### Assign parameters depending on current profile
     @staticmethod
     def assign_profile():
-        LmConf.LiveboxURL = LmTools.clean_url(LmConf.CurrProfile.get("Livebox URL", DCFG_LIVEBOX_URL))
+        LmConf.LiveboxURL = LmUtils.clean_url(LmConf.CurrProfile.get("Livebox URL", DCFG_LIVEBOX_URL))
         LmConf.LiveboxUser = LmConf.CurrProfile.get("Livebox User", DCFG_LIVEBOX_USER)
 
         p = LmConf.CurrProfile.get("Livebox Password")
@@ -767,7 +768,7 @@ class LmConf:
             try:
                 LmConf.LiveboxPassword = Fernet(LmConf.Secret.encode("utf-8")).decrypt(p.encode("utf-8")).decode("utf-8")
             except Exception:
-                LmTools.error("Cannot decrypt Livebox password.")
+                LmUtils.error("Cannot decrypt Livebox password.")
                 LmConf.LiveboxPassword = DCFG_LIVEBOX_PASSWORD
         else:
             LmConf.LiveboxPassword = DCFG_LIVEBOX_PASSWORD
@@ -847,15 +848,15 @@ class LmConf:
 
         # Create config directory if doesn't exist
         if not os.path.isdir(config_path):
-            LmTools.log_debug(1, "Creating config directory", config_path)
+            LmUtils.log_debug(1, "Creating config directory", config_path)
             try:
                 os.makedirs(config_path)
             except Exception as e:
-                LmTools.error(f"Cannot create configuration folder. Error: {e}")
+                LmUtils.error(f"Cannot create configuration folder. Error: {e}")
                 return
 
         config_file_path = os.path.join(config_path, CONFIG_FILE)
-        LmTools.log_debug(1, "Saving configuration in", config_file_path)
+        LmUtils.log_debug(1, "Saving configuration in", config_file_path)
         try:
             with open(config_file_path, "w") as config_file:
                 config = {}
@@ -904,7 +905,7 @@ class LmConf:
                 config["Save Passwords"] = LmConf.SavePasswords
                 json.dump(config, config_file, indent=4)
         except Exception as e:
-            LmTools.error(f"Cannot save configuration file. Error: {e}")
+            LmUtils.error(f"Cannot save configuration file. Error: {e}")
 
 
     ### Set Livebox password
@@ -938,7 +939,7 @@ class LmConf:
         elif level > 2:
             level = 2
         LmConf.LogLevel = level
-        LmTools.set_verbosity(level)
+        LmUtils.set_verbosity(level)
         LmConf.save()
 
 
@@ -957,7 +958,7 @@ class LmConf:
                     try:
                         password = Fernet(LmConf.Secret.encode("utf-8")).decrypt(p.encode("utf-8")).decode("utf-8")
                     except Exception:
-                        LmTools.error("Cannot decrypt repeater password.")
+                        LmUtils.error("Cannot decrypt repeater password.")
                         password = LmConf.LiveboxPassword
                 return user, password
 
@@ -1017,7 +1018,7 @@ class LmConf:
             try:
                 os.makedirs(config_path)
             except Exception as e:
-                LmTools.error(f"Cannot create configuration folder. Error: {e}")
+                LmUtils.error(f"Cannot create configuration folder. Error: {e}")
                 return
 
         mac_addr_table_file_path = os.path.join(config_path, LmConf.MacAddrTableFile)
@@ -1025,7 +1026,7 @@ class LmConf:
             with open(mac_addr_table_file_path, "w") as mac_table_file:
                 json.dump(LmConf.MacAddrTable, mac_table_file, indent=4)
         except Exception as e:
-            LmTools.error(f"Cannot save MacAddress file. Error: {e}")
+            LmUtils.error(f"Cannot save MacAddress file. Error: {e}")
 
 
     ### Load spam calls table
@@ -1073,7 +1074,7 @@ class LmConf:
             try:
                 os.makedirs(config_path)
             except Exception as e:
-                LmTools.error(f"Cannot create configuration folder. Error: {e}")
+                LmUtils.error(f"Cannot create configuration folder. Error: {e}")
                 return
 
         spam_calls_table_file_path = os.path.join(config_path, SPAMCALLS_FILE)
@@ -1081,7 +1082,7 @@ class LmConf:
             with open(spam_calls_table_file_path, "w") as f:
                 json.dump(LmConf.SpamCallsTable, f, indent = 4)
         except Exception as e:
-            LmTools.error(f"Cannot save spam calls file. Error: {e}")
+            LmUtils.error(f"Cannot save spam calls file. Error: {e}")
 
 
     ### Set native run
@@ -1117,7 +1118,7 @@ class LmConf:
             icon_pixmap = QtGui.QPixmap()
             if not icon_pixmap.load(icon_file_path):
                 icon_pixmap = None
-                LmTools.error(f"Cannot load device icon cache file {icon_file_path}. Cache file will be recreated.")
+                LmUtils.error(f"Cannot load device icon cache file {icon_file_path}. Cache file will be recreated.")
         return icon_pixmap
 
 
@@ -1132,7 +1133,7 @@ class LmConf:
             try:
                 os.makedirs(icon_dir_path)
             except Exception as e:
-                LmTools.error(f"Cannot create icon cache folder {icon_dir_path}. Error: {e}")
+                LmUtils.error(f"Cannot create icon cache folder {icon_dir_path}. Error: {e}")
                 return
 
         # Create and save icon cache file
@@ -1140,7 +1141,7 @@ class LmConf:
             with open(icon_file_path, "wb") as icon_file:
                 icon_file.write(content)
         except Exception as e:
-            LmTools.error(f"Cannot save icon cache file {icon_file_path}. Error: {e}")
+            LmUtils.error(f"Cannot save icon cache file {icon_file_path}. Error: {e}")
 
 
     ### Get a device icon
@@ -1166,11 +1167,11 @@ class LmConf:
                     if icon_pixmap.loadFromData(icon_data.content):
                         store_in_cache = True
                     else:
-                        LmTools.error(f"Cannot load device icon {device['Icon']}.")
+                        LmUtils.error(f"Cannot load device icon {device['Icon']}.")
                 except requests.exceptions.Timeout as e:
-                    LmTools.error(f"Device icon {device['Icon']} request timeout error: {e}.")
+                    LmUtils.error(f"Device icon {device['Icon']} request timeout error: {e}.")
                 except Exception as e:
-                    LmTools.error(f"{e}. Cannot request device icon {device['Icon']}.")
+                    LmUtils.error(f"{e}. Cannot request device icon {device['Icon']}.")
 
                 # If successfully loaded, try to store in local cache file for faster further loads
                 if store_in_cache:
@@ -1235,7 +1236,7 @@ class LmConf:
                         DEVICE_TYPES.append(device)
                         sort_device_types = True
                 else:
-                    LmTools.error(f"Cannot load custom device icon {icon_file_path}.")
+                    LmUtils.error(f"Cannot load custom device icon {icon_file_path}.")
 
         # Resort device type list if required
         if sort_device_types:
@@ -1267,7 +1268,7 @@ class LmConf:
             try:
                 password = Fernet(LmConf.Secret.encode("utf-8")).decrypt(p.encode("utf-8")).decode("utf-8")
             except Exception:
-                LmTools.error("Cannot decrypt email password.")
+                LmUtils.error("Cannot decrypt email password.")
         e["Password"] = password
 
         return e
@@ -1280,6 +1281,6 @@ class LmConf:
         try:
             email_setup["Password"] = Fernet(LmConf.Secret.encode("utf-8")).encrypt(p.encode("utf-8")).decode("utf-8")
         except Exception:
-            LmTools.error("Cannot encrypt email password.")
+            LmUtils.error("Cannot encrypt email password.")
             email_setup["Password"] = ""
         LmConf.Email = email_setup

--- a/src/LiveboxMonitor/app/LmGenApiDocumentation.py
+++ b/src/LiveboxMonitor/app/LmGenApiDocumentation.py
@@ -3,7 +3,7 @@
 import os
 import json
 
-from LiveboxMonitor.app import LmTools
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -157,13 +157,13 @@ class LmGenApiDoc:
         try:
             d = self._api._intf.get_key_list()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
         else:
             if isinstance(d, list):
                 for m in d:
                     self.gen_service_file("NeMo.Intf." + m)
             else:
-                LmTools.error("Bad return from interface list API.")
+                LmUtils.error("Bad return from interface list API.")
 
 
     ### Generate all services in a flat file
@@ -184,7 +184,7 @@ class LmGenApiDoc:
         try:
             d = self._session.request(service, get=True, timeout=15)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return
 
         if d is None:
@@ -198,7 +198,7 @@ class LmGenApiDoc:
         try:
             self._file = open(file_path, "w")
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return
 
         self._file.write(f"=== LIVEBOX SOFTWARE VERSION: {self._software_version}\n\n")
@@ -207,7 +207,7 @@ class LmGenApiDoc:
         try:
             self._file.close()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
         self._file = None
 
 
@@ -221,7 +221,7 @@ class LmGenApiDoc:
         try:
             d = self._session.request(service, get=True, timeout=15)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return
 
         if d is None:
@@ -235,7 +235,7 @@ class LmGenApiDoc:
         try:
             self._file = open(file_path, "w")
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return
 
         self._file.write(f"=== LIVEBOX SOFTWARE VERSION: {self._software_version}\n\n")
@@ -248,7 +248,7 @@ class LmGenApiDoc:
         try:
             self._file.close()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
         self._file = None
 
 

--- a/src/LiveboxMonitor/app/LmTask.py
+++ b/src/LiveboxMonitor/app/LmTask.py
@@ -3,6 +3,7 @@
 from PyQt6 import QtCore
 
 from LiveboxMonitor.app import LmTools
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ LmTask class ################################
@@ -19,7 +20,7 @@ class LmTask:
         self._stack.append(task)
         LmTools.mouse_cursor_busy() # Stack cursor change
         self.display(task)
-        LmTools.log_debug(1, f"TASK STARTING stack={self._index} task={task}")
+        LmUtils.log_debug(1, f"TASK STARTING stack={self._index} task={task}")
 
 
     ### Suspend a potential running task
@@ -39,7 +40,7 @@ class LmTask:
         if self._index:
             task = self._stack[self._index - 1]
             self.display(f"{task} {status}." if task else f"{status}.")
-            LmTools.log_debug(1, f"TASK UPDATE stack={self._index} - task={task} - status={status}")
+            LmUtils.log_debug(1, f"TASK UPDATE stack={self._index} - task={task} - status={status}")
 
 
     ### End a (nested) task
@@ -56,7 +57,7 @@ class LmTask:
                 task = "<None>"
                 self.display(None)
 
-            LmTools.log_debug(1, f"TASK ENDING stack={self._index} - restoring={task}")
+            LmUtils.log_debug(1, f"TASK ENDING stack={self._index} - restoring={task}")
 
 
     ### Display task / erase status is None

--- a/src/LiveboxMonitor/app/LmTools.py
+++ b/src/LiveboxMonitor/app/LmTools.py
@@ -1,60 +1,18 @@
 ### Livebox Monitor tools module ###
 
-import sys
-import functools
 import re
-import datetime, time 
-import smtplib
-import ssl
 
 from enum import IntEnum
-from dateutil import tz
-from email.message import EmailMessage
-from email.utils import formatdate
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.lang import LmLanguages
 from LiveboxMonitor.lang.LmLanguages import get_tools_label as lx
+from LiveboxMonitor.util.LmUtils import error, send_email
 
 
 # ################################ VARS & DEFS ################################
 
-# Debug verbosity
-verbosity = 1
-
-# Regular expressions - https://ihateregex.io/
-MAC_RS = r"(?:[0-9A-Fa-f]{2}[:-]){5}(?:[0-9A-Fa-f]{2})"
-IPv4_RS = r"(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}"
-IPv4Pfix_RS = r"((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\/(3[0-2]|[12]?[0-9]))?"
-IPv6_RS = (r"(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|"
-           r"([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|"
-           r"([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|"
-           r"([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|"
-           r":((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|"
-           r"::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|"
-           r"1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.)"
-           r"{3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))")
-IPv6Pfix_RS = (r"(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|"
-               r"(?:[0-9A-Fa-f]{1,4}:){1,5}(:[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,4}(:[0-9A-Fa-f]{1,4}){1,3}|"
-               r"(?:[0-9A-Fa-f]{1,4}:){1,3}(:[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,2}(:[0-9A-Fa-f]{1,4}){1,5}|"
-               r"[0-9A-Fa-f]{1,4}:((:[0-9A-Fa-f]{1,4}){1,6})|:(?:(:[0-9A-Fa-f]{1,4}){1,7}|:)|fe80:(:[0-9A-Fa-f]{0,4}){0,4}%[0-9a-zA-Z]{1,}|"
-               r"::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|"
-               r"([0-9A-Fa-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))"
-               r"(?:\/(?:12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))?")
-PORTS_RS = (r"^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$|"
-            r"^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})-(6553[0-5]|"
-            r"655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$")
-EMAIL_RS = r"[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+"
-
 # Useful objects
-MAC_RE = re.compile(MAC_RS)
-IPv4_RE = re.compile(f"^{IPv4_RS}$")
-IPv4Pfix_RE = re.compile(f"^{IPv4Pfix_RS}$")
-IPv6_RE = re.compile(f"^{IPv6_RS}$")
-IPv6Pfix_RE = re.compile(f"^{IPv6Pfix_RS}$")
-PORTS_RE = re.compile(PORTS_RS)
-EMAIL_RE = re.compile(EMAIL_RS)
 BOLD_FONT = QtGui.QFont()
 BOLD_FONT.setBold(True)
 
@@ -75,28 +33,6 @@ class ItemDataRole(IntEnum):
 
 
 # ################################ Tools ################################
-
-### Set verbosity
-def set_verbosity(level):
-    global verbosity
-    verbosity = level
-
-
-### Get verbosity
-def get_verbosity():
-    return verbosity
-
-
-### Debug logging according to level
-def log_debug(level, *args):
-    if verbosity >= level:
-        sys.stderr.write(f"###DEBUG-L{level}: {' '.join(args)}\n")
-
-
-### Output error on stderr
-def error(*args, **kwargs):
-    print("###ERROR:", *args, file=sys.stderr, **kwargs)
-
 
 ### Display an error popup
 def display_error(error_msg, parent=None):
@@ -153,156 +89,6 @@ def mouse_cursor_force_normal():
     QtWidgets.QApplication.changeOverrideCursor(QtGui.QCursor(QtCore.Qt.CursorShape.ArrowCursor))
 
 
-### Extract a valid MAC Addr from any string
-def extract_mac_addr_from_string(string):
-    match = re.search(MAC_RE, string) 
-    if match is None:
-        return ""
-    return match.group(0)
-
-
-### Check if valid MAC address
-def is_mac_addr(string):
-    return re.fullmatch(MAC_RE, string) is not None
-
-
-### Check if valid IPv4 address
-def is_ipv4(string):
-    return re.fullmatch(IPv4_RE, string) is not None
-
-
-### Check if valid IPv4 address or IPv4 prefix
-def is_ipv4_pfix(string):
-    return re.fullmatch(IPv4Pfix_RE, string) is not None
-
-
-### Check if valid IPv6 address
-def is_ipv6(string):
-    return re.fullmatch(IPv6_RE, string) is not None
-
-
-### Check if valid IPv6 address or IPv6 prefix
-def is_ipv6_pfix(string):
-    return re.fullmatch(IPv6Pfix_RE, string) is not None
-
-
-### Check if valid TCP/UDP port or ports range
-def is_tcp_udp_port(string):
-    return re.fullmatch(PORTS_RE, string) is not None
-
-
-### Cleanup URL
-def clean_url(url):
-    n = len(url)
-    if n:
-        if not url[n - 1] == "/":
-            url += "/"
-        if not url.startswith("http://") and not url.startswith("https://"):
-            url = "http://" + url
-    return url
-
-
-
-### Determine device IPv4 address info from IPv4 list, return the struct, none if nothing found
-def determine_ip(device):
-    if device is not None:
-        # Retrieve the list
-        ipv4_list = device.get("IPv4Address", [])
-
-        # If only one, return it
-        if len(ipv4_list) == 1:
-            return ipv4_list[0]
-
-        # Retrieve the reference IP address, but it can be an IPv6
-        ref_ip = device.get("IPAddress")
-        if ref_ip is not None:
-            if not is_ipv4(ref_ip):
-                ref_ip = None
-
-        # If there is no ref, return the first reachable address, otherwise the first
-        if ref_ip is None:
-            for i in ipv4_list:
-                if i.get("Status", "") == "reachable":
-                    return i
-            if len(ipv4_list) > 1:
-                return ipv4_list[0]
-
-        # If we have a ref, search for it in the list
-        else:
-            for i in ipv4_list:
-                if ref_ip == i.get("Address", ""):
-                    return i
-
-            # If nothing found, build artificially a struct
-            return {"Address": ref_ip,
-                    "Status": "",
-                    "Reserved": False}
-
-    return None
-
-
-### Send an email, returns true if successful
-def send_email(email_setup, subject, message):
-    # Create a text/plain message
-    m = EmailMessage()
-    m["From"] = email_setup["From"]
-    m["To"] = email_setup["To"]
-    m["Date"] = formatdate(localtime=True)
-    m["Subject"] = email_setup["Prefix"] + subject
-
-    # Message body
-    try:
-        m.set_content(message)
-    except Exception as e:
-        error(f"Cannot set email content. Error: {e}")
-        return False
-
-    # Create a session
-    s = None
-    try:
-        if email_setup["TLS"]:
-            s = smtplib.SMTP(email_setup["Server"], email_setup["Port"], timeout=SMTP_TIMEOUT)
-            s.starttls(context=ssl.create_default_context())
-        elif email_setup["SSL"]:
-            s = smtplib.SMTP_SSL(email_setup["Server"], email_setup["Port"], timeout=SMTP_TIMEOUT, context=ssl.create_default_context())
-        else:
-            s = smtplib.SMTP(email_setup["Server"], email_setup["Port"], timeout=SMTP_TIMEOUT)
-    except Exception as e:
-        error(f"Cannot setup email session. Error: {e}")
-        if s is not None:
-            try:
-                s.quit()
-            except Exception:
-                pass
-        return False
-
-    # Authenticate if necessary
-    if email_setup["Authentication"]:
-        try:
-            s.login(email_setup["User"], email_setup["Password"])
-        except Exception as e:
-            error(f"Authentication to SMTP server failed. Error: {e}")
-            try:
-                s.quit()
-            except Exception:
-                pass
-            return False
-
-    # Send the message
-    try:
-        s.send_message(m)
-    except Exception as e:
-        error(f"Cannot send email. Error: {e}")
-        try:
-            s.quit()
-        except Exception:
-            pass
-        return False
-
-    s.quit()
-    return True
-
-
 ### Async email sending task
 class AsyncEmail(QtCore.QRunnable):
     def __init__(self, email_setup, subject, message):
@@ -327,94 +113,6 @@ def async_send_email(email_setup, subject, message):
 
 
 # ################################ Formatting Tools ################################
-
-### Format number of bytes
-def fmt_bytes(bytes_nb, suffix="B"):
-    for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
-        if abs(bytes_nb) < 1024.0:
-            return f"{bytes_nb:3.1f} {unit}{suffix}"
-        bytes_nb /= 1024.0
-    return f"{bytes_nb:.1f} Y{suffix}"
-
-
-### Format boolean value
-def fmt_bool(bool_val):
-    if bool_val is None:
-        return ""
-    if bool_val:
-        return lx("True")
-    return lx("False")
-
-
-### Format integer value
-def fmt_int(int_val):
-    if int_val is None:
-        return ""
-    return str(int_val)
-
-
-### Format a string with capitalize
-def fmt_str_capitalize(string):
-    if string is None:
-        return ""
-    return string.capitalize()
-
-
-### Format a string in upper string
-def fmt_str_upper(string):
-    if string is None:
-        return ""
-    return string.upper()
-
-
-### Format time
-def fmt_time(seconds, no_zero=False):
-    if seconds is None:
-        return ""
-
-    days = seconds // (24 * 3600)
-    n = seconds % (24 * 3600)
-    hours = n // 3600
-    n %= 3600
-    minutes = n // 60
-    seconds = n % 60
-
-    if no_zero:
-        if days:
-            return f"{days:02d}d {hours:02d}h {minutes:02d}m {seconds:02d}s"
-        elif hours:
-            return f"{hours:02d}h {minutes:02d}m {seconds:02d}s"
-        elif minutes:
-            return f"{minutes:02d}m {seconds:02d}s"
-        elif seconds:
-            return f"{seconds:02d}s"
-        else:
-            return ""
-    else:
-        return f"{days:02d}d {hours:02d}h {minutes:02d}m {seconds:02d}s"
-
-
-### Format Livebox timestamps
-def fmt_livebox_timestamp(timestamp, utc=True):
-    if timestamp is None:
-        return ""
-    date_time = livebox_timestamp(timestamp, utc)
-    if date_time is None:
-        return ""
-    return date_time.strftime("%Y-%m-%d %H:%M:%S")
-
-
-### Parse Livebox timestamp (UTC time by default)
-def livebox_timestamp(timestamp, utc=True):
-    try:
-        if utc:
-            return datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00")).replace(tzinfo = tz.tzutc()).astimezone(tz.tzlocal())
-        else:
-            return datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    except Exception:
-        return None
-
-
 
 # ############# Display text dialog #############
 class TextDialog(QtWidgets.QDialog):

--- a/src/LiveboxMonitor/dlg/LmBackupRestore.py
+++ b/src/LiveboxMonitor/dlg/LmBackupRestore.py
@@ -2,9 +2,10 @@
 
 from PyQt6 import QtCore, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.lang.LmLanguages import get_backup_restore_label as lx, get_actions_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ Backup & Restore setup dialog ################################
@@ -85,7 +86,7 @@ class BackupRestoreDialog(QtWidgets.QDialog):
         try:
             d = self._api._backup.get_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Cannot load backup and restore status.", "backRestSvcErr"))
             return
 
@@ -100,7 +101,7 @@ class BackupRestoreDialog(QtWidgets.QDialog):
 
         last_backup = d.get("ConfigDate")
         if last_backup:
-            self._last_backup.setText(LmTools.fmt_livebox_timestamp(last_backup, False))
+            self._last_backup.setText(LmUtils.fmt_livebox_timestamp(last_backup, False))
         else:
             self._last_backup.setText("-")
 
@@ -109,7 +110,7 @@ class BackupRestoreDialog(QtWidgets.QDialog):
         try:
             self._api._backup.set_auto_backup_enable(True)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Cannot enable auto backup.", "backEnableSvcErr"))
         else:
             self.refresh_status()
@@ -119,7 +120,7 @@ class BackupRestoreDialog(QtWidgets.QDialog):
         try:
             self._api._backup.set_auto_backup_enable(False)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Cannot disable auto backup.", "backDisableSvcErr"))
         else:
             self.refresh_status()
@@ -129,7 +130,7 @@ class BackupRestoreDialog(QtWidgets.QDialog):
         try:
             self._api._backup.do_backup()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Backup request failed.", "backupSvcErr"))
         else:
             self._app.display_status(mx("Backup requested.", "backupSvcOk"))
@@ -140,7 +141,7 @@ class BackupRestoreDialog(QtWidgets.QDialog):
         try:
             self._api._backup.do_restore()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Restore request failed.", "restoreSvcErr"))
         else:
             self._app.display_status(mx("Restore requested. Livebox will restart.", "restoreSvcOk"))

--- a/src/LiveboxMonitor/dlg/LmDhcpBinding.py
+++ b/src/LiveboxMonitor/dlg/LmDhcpBinding.py
@@ -2,9 +2,10 @@
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.lang.LmLanguages import get_dhcp_binding_label as lx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ Add DHCP binding setup dialog ################################
@@ -26,7 +27,7 @@ class AddDhcpBindingDialog(QtWidgets.QDialog):
 
         mac_label = QtWidgets.QLabel(lx("MAC address"), objectName="macLabel")
         self._mac_edit = QtWidgets.QLineEdit(objectName="macEdit")
-        mac_reg_exp = QtCore.QRegularExpression("^" + LmTools.MAC_RS + "$")
+        mac_reg_exp = QtCore.QRegularExpression("^" + LmUtils.MAC_RS + "$")
         mac_validator = QtGui.QRegularExpressionValidator(mac_reg_exp)
         self._mac_edit.setValidator(mac_validator)
         self._mac_edit.textChanged.connect(self.mac_typed)
@@ -38,7 +39,7 @@ class AddDhcpBindingDialog(QtWidgets.QDialog):
 
         ip_label = QtWidgets.QLabel(lx("IP address"), objectName="ipLabel")
         self._ip_edit = QtWidgets.QLineEdit(objectName="ipEdit")
-        ip_reg_exp = QtCore.QRegularExpression("^" + LmTools.IPv4_RS + "$")
+        ip_reg_exp = QtCore.QRegularExpression("^" + LmUtils.IPv4_RS + "$")
         ip_validator = QtGui.QRegularExpressionValidator(ip_reg_exp)
         self._ip_edit.setValidator(ip_validator)
         self._ip_edit.textChanged.connect(self.ip_typed)

--- a/src/LiveboxMonitor/dlg/LmDhcpSetup.py
+++ b/src/LiveboxMonitor/dlg/LmDhcpSetup.py
@@ -2,8 +2,9 @@
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.lang.LmLanguages import get_dhcp_setup_label as lx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ DHCP Setup dialog ################################
@@ -15,7 +16,7 @@ class DhcpSetupDialog(QtWidgets.QDialog):
         self._enable_checkbox = QtWidgets.QCheckBox(lx("DHCP Enabled"), objectName="enableCheckbox")
         self._enable_checkbox.setChecked(enabled)
 
-        ip_reg_exp = QtCore.QRegularExpression("^" + LmTools.IPv4_RS + "$")
+        ip_reg_exp = QtCore.QRegularExpression("^" + LmUtils.IPv4_RS + "$")
         ip_validator = QtGui.QRegularExpressionValidator(ip_reg_exp)
 
         livebox_ip_label = QtWidgets.QLabel(lx("Livebox IP address"), objectName="liveboxIpLabel")

--- a/src/LiveboxMonitor/dlg/LmDmz.py
+++ b/src/LiveboxMonitor/dlg/LmDmz.py
@@ -7,6 +7,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from LiveboxMonitor.app import LmTools, LmConfig
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget
 from LiveboxMonitor.lang.LmLanguages import get_dmz_label as lx, get_actions_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -79,7 +80,7 @@ class DmzSetupDialog(QtWidgets.QDialog):
         ip_label = QtWidgets.QLabel(lx("IP Address"), objectName="ipLabel")
         self._ip = QtWidgets.QLineEdit(objectName="ipEdit")
         self._ip.textChanged.connect(self.ip_typed)
-        ip_validator = QtGui.QRegularExpressionValidator(QtCore.QRegularExpression("^" + LmTools.IPv4_RS + "$"))
+        ip_validator = QtGui.QRegularExpressionValidator(QtCore.QRegularExpression("^" + LmUtils.IPv4_RS + "$"))
         self._ip.setValidator(ip_validator)
         ext_ips_label = QtWidgets.QLabel(lx("External IPs"), objectName="extIPsLabel")
         self._ext_ips = LmTools.MultiLinesEdit(objectName="extIPsEdit")
@@ -206,7 +207,7 @@ class DmzSetupDialog(QtWidgets.QDialog):
         try:
             self._api._firewall.delete_dmz(dmz_id)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Cannot delete DMZ device.", "dmzDelErr"))
             return
 

--- a/src/LiveboxMonitor/dlg/LmDns.py
+++ b/src/LiveboxMonitor/dlg/LmDns.py
@@ -4,9 +4,10 @@ from enum import IntEnum
 
 from PyQt6 import QtCore, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget, CenteredIconsDelegate
 from LiveboxMonitor.lang.LmLanguages import get_dns_label as lx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -94,7 +95,7 @@ class DnsDialog(QtWidgets.QDialog):
                     active_icon = app.format_active_table_widget(active_status)
                     self._device_table.setItem(i, DnsCol.Active, active_icon)
 
-                    ip_struct = LmTools.determine_ip(d)
+                    ip_struct = LmUtils.determine_ip(d)
                     if ip_struct is None:
                         ipv4 = ""
                         ipv4_reacheable = ""

--- a/src/LiveboxMonitor/dlg/LmDynDns.py
+++ b/src/LiveboxMonitor/dlg/LmDynDns.py
@@ -4,10 +4,10 @@ from enum import IntEnum
 
 from PyQt6 import QtCore, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget
 from LiveboxMonitor.lang.LmLanguages import get_dyndns_label as lx, get_actions_message as mx
-
+from LiveboxMonitor.util import LmUtils
 
 # ################################ VARS & DEFS ################################
 
@@ -148,7 +148,7 @@ class DynDnsSetupDialog(QtWidgets.QDialog):
             try:
                 d = self._api._dyndns.get_hosts()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self._app.display_error(mx("Cannot load DynDNS host list.", "dynDnsLoadErr"))
                 return
 
@@ -161,7 +161,7 @@ class DynDnsSetupDialog(QtWidgets.QDialog):
                     self._host_list.setItem(i, HostCol.Password, QtWidgets.QTableWidgetItem(h.get("password", "")))
                 else:
                     self._host_list.setItem(i, HostCol.Password, QtWidgets.QTableWidgetItem("******"))
-                self._host_list.setItem(i, HostCol.LastUpdate, QtWidgets.QTableWidgetItem(LmTools.fmt_livebox_timestamp(h.get("last_update"))))
+                self._host_list.setItem(i, HostCol.LastUpdate, QtWidgets.QTableWidgetItem(LmUtils.fmt_livebox_timestamp(h.get("last_update"))))
                 self._host_list.setItem(i, HostCol.Status, QtWidgets.QTableWidgetItem(h.get("status", "")))
 
             self.host_list_click()
@@ -187,7 +187,7 @@ class DynDnsSetupDialog(QtWidgets.QDialog):
         try:
             d = self._api._dyndns.get_services()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Cannot load DynDNS services.", "dynDnsSvcErr"))
             return
 
@@ -235,7 +235,7 @@ class DynDnsSetupDialog(QtWidgets.QDialog):
         try:
             self._api._dyndns.delete_host(hostname)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self._app.display_error(mx("Cannot delete DynDNS host.", "dynDnsDelErr"))
             return
 
@@ -285,10 +285,10 @@ class DynDnsSetupDialog(QtWidgets.QDialog):
         try:
             d = self._api._dyndns.get_enable()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return False
         if d is None:
-            LmTools.error(mx("Cannot get DynDNS global enable status.", "dynDnsEnableErr"))
+            LmUtils.error(mx("Cannot get DynDNS global enable status.", "dynDnsEnableErr"))
             return False
         return d
 
@@ -299,7 +299,7 @@ class DynDnsSetupDialog(QtWidgets.QDialog):
         try:
             self._api._dyndns.set_enable(enable)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
 
         self._disable_button.setText(self.get_disable_button_title())
         self.refresh_button_click()

--- a/src/LiveboxMonitor/dlg/LmEmailSetup.py
+++ b/src/LiveboxMonitor/dlg/LmEmailSetup.py
@@ -2,10 +2,10 @@
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.lang.LmLanguages import get_config_email_label as lx,  get_config_message as mx
-
+from LiveboxMonitor.util import LmUtils
 
 # ################################ Email setup dialog ################################
 class EmailSetupDialog(QtWidgets.QDialog):
@@ -15,7 +15,7 @@ class EmailSetupDialog(QtWidgets.QDialog):
 
         self._init = True
 
-        email_reg_exp = QtCore.QRegularExpression(LmTools.EMAIL_RS)
+        email_reg_exp = QtCore.QRegularExpression(LmUtils.EMAIL_RS)
         email_validator = QtGui.QRegularExpressionValidator(email_reg_exp)
 
         from_addr_label = QtWidgets.QLabel(lx("From Address"), objectName="fromAddrLabel")
@@ -35,7 +35,7 @@ class EmailSetupDialog(QtWidgets.QDialog):
         self._smtp_server = QtWidgets.QLineEdit(objectName="smtpServerEdit")
         self._smtp_server.textChanged.connect(self.setup_changed)
 
-        port_reg_exp = QtCore.QRegularExpression(LmTools.PORTS_RS)
+        port_reg_exp = QtCore.QRegularExpression(LmUtils.PORTS_RS)
         port_validator = QtGui.QRegularExpressionValidator(port_reg_exp)
         smtp_port_label = QtWidgets.QLabel(lx("Port"), objectName="smtpPortLabel")
         self._smtp_port = QtWidgets.QLineEdit(objectName="smtpPortEdit")
@@ -162,7 +162,7 @@ class EmailSetupDialog(QtWidgets.QDialog):
         app = self.parentWidget()
         app._task.start(lx("Sending test email..."))
         c = self.get_setup()
-        if LmTools.send_email(c, lx("Test Message"), lx("This is a test email from LiveboxMonitor.")):
+        if LmUtils.send_email(c, lx("Test Message"), lx("This is a test email from LiveboxMonitor.")):
             app.display_status(mx("Message sent successfully.", "emailSuccess"))
         else:
             app.display_error(mx("Message send failure. Check your setup.", "emailFail"))

--- a/src/LiveboxMonitor/dlg/LmExportTable.py
+++ b/src/LiveboxMonitor/dlg/LmExportTable.py
@@ -7,6 +7,7 @@ from PyQt6 import QtCore, QtWidgets
 from LiveboxMonitor.app import LmTools, LmConfig
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.lang.LmLanguages import get_export_table_label as lx, get_main_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ Export table dialog ################################
@@ -71,7 +72,7 @@ class ExportTableDialog(QtWidgets.QDialog):
         try:
             export_file = open(file_name, "w", newline="")
         except Exception as e:
-            LmTools.error(f"File creation error: {e}")
+            LmUtils.error(f"File creation error: {e}")
             self._app.display_error(mx("Cannot create the file.", "createFileErr"))
             return
 
@@ -98,7 +99,7 @@ class ExportTableDialog(QtWidgets.QDialog):
         try:
             export_file.close()
         except Exception as e:
-            LmTools.error(f"File saving error: {e}")
+            LmUtils.error(f"File saving error: {e}")
             self._app.display_error(mx("Cannot save the file.", "saveFileErr"))
  
         self._app._task.end()

--- a/src/LiveboxMonitor/dlg/LmIPv6.py
+++ b/src/LiveboxMonitor/dlg/LmIPv6.py
@@ -6,10 +6,11 @@ from enum import IntEnum
 
 from PyQt6 import QtCore, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget, CenteredIconsDelegate
 from LiveboxMonitor.lang.LmLanguages import get_ipv6_label as lx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -196,7 +197,7 @@ class IPv6Dialog(QtWidgets.QDialog):
                     active_icon = app.format_active_table_widget(active_status)
                     self._device_table.setItem(i, IPv6Col.Active, active_icon)
 
-                    ip_struct = LmTools.determine_ip(d)
+                    ip_struct = LmUtils.determine_ip(d)
                     if ip_struct is None:
                         ipv4 = ""
                         ipv4_reacheable = ""

--- a/src/LiveboxMonitor/dlg/LmNotificationSetup.py
+++ b/src/LiveboxMonitor/dlg/LmNotificationSetup.py
@@ -11,6 +11,7 @@ from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget, CenteredIconHeaderView, CenteredIconsDelegate
 from LiveboxMonitor.lang.LmLanguages import get_notification_rules_label as lx, get_events_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -102,7 +103,7 @@ class NotificationSetupDialog(QtWidgets.QDialog):
 
         mac_label = QtWidgets.QLabel(lx("MAC address"), objectName="macLabel")
         self._mac_edit = QtWidgets.QLineEdit(objectName="macEdit")
-        mac_reg_exp = QtCore.QRegularExpression("^" + LmTools.MAC_RS + "$")
+        mac_reg_exp = QtCore.QRegularExpression("^" + LmUtils.MAC_RS + "$")
         mac_validator = QtGui.QRegularExpressionValidator(mac_reg_exp)
         self._mac_edit.setValidator(mac_validator)
         self._mac_edit.textChanged.connect(self.mac_typed)
@@ -510,7 +511,7 @@ class NotificationSetupDialog(QtWidgets.QDialog):
             k = r["Key"]
             if k != LmNotif.DEVICE_ALL and k != LmNotif.DEVICE_UNKNOWN:
                 m = self._mac_edit.text()
-                if not LmTools.is_mac_addr(m):
+                if not LmUtils.is_mac_addr(m):
                         self.parent().display_error(mx("{} is not a valid MAC address.", "macErr").format(m))
                         self._mac_edit.setFocus()
                         return False
@@ -628,7 +629,7 @@ class NotificationSetupDialog(QtWidgets.QDialog):
                 try:
                     os.makedirs(p)
                 except Exception as e:
-                    LmTools.error(f"Cannot create log file directory. Error: {e}")
+                    LmUtils.error(f"Cannot create log file directory. Error: {e}")
                     LmTools.display_error(mx("Cannot create log file directory.\nError: {}.", "logDirErr").format(e))
                     return False
             else:

--- a/src/LiveboxMonitor/dlg/LmPatRule.py
+++ b/src/LiveboxMonitor/dlg/LmPatRule.py
@@ -4,6 +4,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from LiveboxMonitor.app import LmTools, LmConfig, LmPatPtf
 from LiveboxMonitor.lang.LmLanguages import get_pat_rule_label as lx, get_nat_pat_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ PAT rule dialog ################################
@@ -40,7 +41,7 @@ class PatRuleDialog(QtWidgets.QDialog):
         protocols_box.addWidget(self._tcp_checkbox, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
         protocols_box.addWidget(self._udp_checkbox, 1, QtCore.Qt.AlignmentFlag.AlignLeft)
 
-        port_regexp = QtCore.QRegularExpression(LmTools.PORTS_RS)
+        port_regexp = QtCore.QRegularExpression(LmUtils.PORTS_RS)
         port_validator = QtGui.QRegularExpressionValidator(port_regexp)
 
         int_port_label = QtWidgets.QLabel(lx("Internal Port"), objectName="intPortLabel")
@@ -186,12 +187,12 @@ class PatRuleDialog(QtWidgets.QDialog):
 
         # Adjust IP field validator
         if self.get_type() == LmPatPtf.RULE_TYPE_IPv6:
-            ip_reg_exp = QtCore.QRegularExpression(f"^{LmTools.IPv6_RS}$")
+            ip_reg_exp = QtCore.QRegularExpression(f"^{LmUtils.IPv6_RS}$")
             if not LmPatPtf.IPV6_SOURCE_PORT_WORKING:
                 self._ext_port_edit.setEnabled(False)
                 self._ext_port_edit.setText("")
         else:
-            ip_reg_exp = QtCore.QRegularExpression(f"^{LmTools.IPv4_RS}$")
+            ip_reg_exp = QtCore.QRegularExpression(f"^{LmUtils.IPv4_RS}$")
             if not LmPatPtf.IPV6_SOURCE_PORT_WORKING:
                 self._ext_port_edit.setEnabled(True)
         self._ip_edit.setValidator(QtGui.QRegularExpressionValidator(ip_reg_exp))
@@ -259,12 +260,12 @@ class PatRuleDialog(QtWidgets.QDialog):
         # Validate IP address
         ip = self.get_ip()
         if t == LmPatPtf.RULE_TYPE_IPv6:
-            if not LmTools.is_ipv6(ip):
+            if not LmUtils.is_ipv6(ip):
                 self.parent().display_error(mx("{} is not a valid IPv6 address.", "ipv6AddrErr").format(ip))
                 self._ip_edit.setFocus()
                 return
         else:
-            if not LmTools.is_ipv4(ip):
+            if not LmUtils.is_ipv4(ip):
                 self.parent().display_error(mx("{} is not a valid IPv4 address.", "ipv4AddrErr").format(ip))
                 self._ip_edit.setFocus()
                 return
@@ -280,12 +281,12 @@ class PatRuleDialog(QtWidgets.QDialog):
                     return
 
                 if t == LmPatPtf.RULE_TYPE_IPv6:
-                    if not LmTools.is_ipv6_pfix(ip):
+                    if not LmUtils.is_ipv6_pfix(ip):
                         self.parent().display_error(mx("{} is not a valid IPv6 address or prefix.", "ipv6AddrPfixErr").format(ip))
                         self._ext_ips_edit.setFocus()
                         return
                 else:
-                    if not LmTools.is_ipv4_pfix(ip):
+                    if not LmUtils.is_ipv4_pfix(ip):
                         self.parent().display_error(mx("{} is not a valid IPv4 address or prefix.", "ipv4AddrPfixErr").format(ip))
                         self._ext_ips_edit.setFocus()
                         return

--- a/src/LiveboxMonitor/dlg/LmPrefs.py
+++ b/src/LiveboxMonitor/dlg/LmPrefs.py
@@ -6,6 +6,7 @@ from LiveboxMonitor.app import LmTools, LmConfig
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.lang import LmLanguages
 from LiveboxMonitor.lang.LmLanguages import get_config_prefs_label as lx,  get_config_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ Preferences dialog ################################
@@ -312,7 +313,7 @@ class PrefsDialog(QtWidgets.QDialog):
         # Save in profiles buffer
         p = self._profiles[self._profile_selection]
         p["Name"] = self._profile_name.text()
-        p["Livebox URL"] = LmTools.clean_url(self._livebox_url.text())
+        p["Livebox URL"] = LmUtils.clean_url(self._livebox_url.text())
         p["Livebox User"] = self._livebox_user.text()
         p["Filter Devices"] = self._filter_devices.isChecked()
         p["MacAddr Table File"] = self._mac_addr_table_file.text()

--- a/src/LiveboxMonitor/dlg/LmPtfRule.py
+++ b/src/LiveboxMonitor/dlg/LmPtfRule.py
@@ -4,6 +4,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from LiveboxMonitor.app import LmTools, LmConfig, LmPatPtf
 from LiveboxMonitor.lang.LmLanguages import get_ptf_rule_label as lx, get_nat_pat_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ PTF rule dialog ################################
@@ -160,9 +161,9 @@ class PtfRuleDialog(QtWidgets.QDialog):
 
         # Adjust IP field validator
         if self.get_type() == LmPatPtf.RULE_TYPE_IPv6:
-            ip_reg_exp = QtCore.QRegularExpression(f"^{LmTools.IPv6Pfix_RS}$")
+            ip_reg_exp = QtCore.QRegularExpression(f"^{LmUtils.IPv6Pfix_RS}$")
         else:
-            ip_reg_exp = QtCore.QRegularExpression(f"^{LmTools.IPv4Pfix_RS}$")
+            ip_reg_exp = QtCore.QRegularExpression(f"^{LmUtils.IPv4Pfix_RS}$")
         self._ip_edit.setValidator(QtGui.QRegularExpressionValidator(ip_reg_exp))
 
 
@@ -224,12 +225,12 @@ class PtfRuleDialog(QtWidgets.QDialog):
         # Validate IP address
         ip = self.get_ip()
         if t == LmPatPtf.RULE_TYPE_IPv6:
-            if not LmTools.is_ipv6_pfix(ip):
+            if not LmUtils.is_ipv6_pfix(ip):
                 self._app.display_error(mx("{} is not a valid IPv6 address or prefix.", "ipv6AddrPfixErr").format(ip))
                 self._ip_edit.setFocus()
                 return
         else:
-            if not LmTools.is_ipv4_pfix(ip):
+            if not LmUtils.is_ipv4_pfix(ip):
                 self._app.display_error(mx("{} is not a valid IPv4 address or prefix.", "ipv4AddrPfixErr").format(ip))
                 self._ip_edit.setFocus()
                 return
@@ -245,12 +246,12 @@ class PtfRuleDialog(QtWidgets.QDialog):
                     return
 
                 if t == LmPatPtf.RULE_TYPE_IPv6:
-                    if not LmTools.is_ipv6_pfix(ip):
+                    if not LmUtils.is_ipv6_pfix(ip):
                         self._app.display_error(mx("{} is not a valid IPv6 address or prefix.", "ipv6AddrPfixErr").format(ip))
                         self._ext_ips_edit.setFocus()
                         return
                 else:
-                    if not LmTools.is_ipv4_pfix(ip):
+                    if not LmUtils.is_ipv4_pfix(ip):
                         self._app.display_error(mx("{} is not a valid IPv4 address or prefix.", "ipv4AddrPfixErr").format(ip))
                         self._ext_ips_edit.setFocus()
                         return

--- a/src/LiveboxMonitor/dlg/LmRebootHistory.py
+++ b/src/LiveboxMonitor/dlg/LmRebootHistory.py
@@ -4,9 +4,10 @@ from enum import IntEnum
 
 from PyQt6 import QtCore, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget
 from LiveboxMonitor.lang.LmLanguages import get_reboot_history_label as lx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -54,7 +55,7 @@ class RebootHistoryDialog(QtWidgets.QDialog):
         for i, key in enumerate(history):
             d = history[key]
             self._history_table.insertRow(i)
-            self._history_table.setItem(i, RebootCol.BootDate, QtWidgets.QTableWidgetItem(LmTools.fmt_livebox_timestamp(d.get("BootDate"))))
+            self._history_table.setItem(i, RebootCol.BootDate, QtWidgets.QTableWidgetItem(LmUtils.fmt_livebox_timestamp(d.get("BootDate"))))
             self._history_table.setItem(i, RebootCol.BootReason, QtWidgets.QTableWidgetItem(d.get("BootReason", lx("Unknown"))))
-            self._history_table.setItem(i, RebootCol.ShutdownDate, QtWidgets.QTableWidgetItem(LmTools.fmt_livebox_timestamp(d.get("ShutdownDate"))))
+            self._history_table.setItem(i, RebootCol.ShutdownDate, QtWidgets.QTableWidgetItem(LmUtils.fmt_livebox_timestamp(d.get("ShutdownDate"))))
             self._history_table.setItem(i, RebootCol.ShutdownReason, QtWidgets.QTableWidgetItem(d.get("ShutdownReason", lx("Unknown"))))

--- a/src/LiveboxMonitor/dlg/LmRouting.py
+++ b/src/LiveboxMonitor/dlg/LmRouting.py
@@ -7,10 +7,11 @@ import string
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget, CenteredIconsDelegate, NumericSortItem
 from LiveboxMonitor.lang.LmLanguages import get_routing_label as lx, get_actions_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -87,7 +88,7 @@ class RoutingSetupDialog(QtWidgets.QDialog):
         rule_group_box.setLayout(rule_layout)
 
         # Add/Modify rule box
-        ip_reg_exp = QtCore.QRegularExpression("^" + LmTools.IPv4_RS + "$")
+        ip_reg_exp = QtCore.QRegularExpression("^" + LmUtils.IPv4_RS + "$")
         ip_validator = QtGui.QRegularExpressionValidator(ip_reg_exp)
 
         dest_network_label = QtWidgets.QLabel(lx("Destination network"), objectName="destNetworkLabel")
@@ -171,7 +172,7 @@ class RoutingSetupDialog(QtWidgets.QDialog):
             try:
                 d = self._api._routing.get_list()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self._app.display_error(mx("Cannot load routing table.", "routingLoadErr"))
                 return
 
@@ -440,7 +441,7 @@ class RoutingSetupDialog(QtWidgets.QDialog):
     def generate_livebox_route(self, rule_name):
         # Validate destination network
         dest_network = self._dest_network.text()
-        if not LmTools.is_ipv4(dest_network):
+        if not LmUtils.is_ipv4(dest_network):
             self._app.display_error(mx("{} is not a valid address.", "addrErr").format(dest_network))
             self._dest_network.setFocus()
             return None
@@ -456,7 +457,7 @@ class RoutingSetupDialog(QtWidgets.QDialog):
 
         # Validate gateway address
         gateway = self._gateway.text()
-        if not LmTools.is_ipv4(gateway):
+        if not LmUtils.is_ipv4(gateway):
             self._app.display_error(mx("{} is not a valid address.", "addrErr").format(gateway))
             self._gateway.setFocus()
             return None

--- a/src/LiveboxMonitor/dlg/LmWifiConfig.py
+++ b/src/LiveboxMonitor/dlg/LmWifiConfig.py
@@ -7,6 +7,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from LiveboxMonitor.app import LmTools, LmConfig
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.lang.LmLanguages import get_wifi_config_label as lx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -188,7 +189,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
             self._duration_edit.setText(str(self._config["Duration"] // 3600))
             timer = self._config["Timer"]
             if timer:
-                self._enable_checkbox.setText(lx(f"Enabled for {LmTools.fmt_time(timer, True)}"))
+                self._enable_checkbox.setText(lx(f"Enabled for {LmUtils.fmt_time(timer, True)}"))
         else:
             self.load_filtering_entries_combo()
 
@@ -246,7 +247,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
     def add_filtering_mac(self):
         mac, ok = QtWidgets.QInputDialog.getText(self._app, lx("MAC Filtering"), lx("Enter MAC address to filter:"))
         if ok and mac:
-            if LmTools.is_mac_addr(mac):
+            if LmUtils.is_mac_addr(mac):
                 # Search if mac address is not already in the list
                 index = self._mac_filtering_entries_combo.findData(mac)
                 if index >= 0:
@@ -304,7 +305,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
         if self._current_freq is not None:
             i = next((i for i in self._config["Intf"] if i["Key"] == self._current_freq), None)
             if i is None:
-                LmTools.error("Internal error, unconsistent configuration - intf not found")
+                LmUtils.error("Internal error, unconsistent configuration - intf not found")
                 self.reject()
                 return
             i["SSID"] = self._ssid_edit.text()
@@ -345,7 +346,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
         secu = i["Secu"]
         secu_list = i["SecuAvail"]
         if secu_list is None:
-            LmTools.error("Internal error, unconsistent configuration - no security list")
+            LmUtils.error("Internal error, unconsistent configuration - no security list")
             self.reject()
         secu_list = secu_list.split(",")
         self._secu_combo.clear()
@@ -362,12 +363,12 @@ class WifiConfigDialog(QtWidgets.QDialog):
             if secu is not None:
                 self._secu_combo.addItem(secu)
                 selection = n
-                LmTools.log_debug(1, f"Warning - security {secu} not in list")
+                LmUtils.log_debug(1, f"Warning - security {secu} not in list")
             elif n == 0:
-                LmTools.error("Internal error, unconsistent configuration - no security")
+                LmUtils.error("Internal error, unconsistent configuration - no security")
                 self.reject()
             else:
-                LmTools.log_debug(1, "Warning - no security, defaulting to first")
+                LmUtils.log_debug(1, "Warning - no security, defaulting to first")
                 selection = 0
 
         if selection >= 0:
@@ -408,7 +409,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
             channels = None
             channels_in_use = None
         if channels is None:
-            LmTools.error("Internal error, unconsistent configuration - no channel list")
+            LmUtils.error("Internal error, unconsistent configuration - no channel list")
             self.reject()
             return
         channels = channels.split(",")
@@ -438,12 +439,12 @@ class WifiConfigDialog(QtWidgets.QDialog):
             if current_channel != "None":
                 self._chan_combo.addItem(current_channel)
                 selection = n
-                LmTools.log_debug(1, f"Warning - channel {secu} not in list")
+                LmUtils.log_debug(1, f"Warning - channel {secu} not in list")
             elif n == 0:
-                LmTools.error("Internal error, unconsistent configuration - no channel")
+                LmUtils.error("Internal error, unconsistent configuration - no channel")
                 self.reject()
             else:
-                LmTools.log_debug(1, "Warning - no channel, defaulting to first")
+                LmUtils.log_debug(1, "Warning - no channel, defaulting to first")
                 selection = 0
 
         if selection >= 0:
@@ -460,7 +461,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
         if modes is not None:
             modes = modes.get("Modes")
         if modes is None:
-            LmTools.error("Internal error, unconsistent configuration - no mode list")
+            LmUtils.error("Internal error, unconsistent configuration - no mode list")
             self.reject()
             return
         modes = modes.split(",")
@@ -480,12 +481,12 @@ class WifiConfigDialog(QtWidgets.QDialog):
             if current_mode is not None:
                 self._mode_combo.addItem(current_mode)
                 selection = n
-                LmTools.log_debug(1, f"Warning - mode {current_mode} not in list")
+                LmUtils.log_debug(1, f"Warning - mode {current_mode} not in list")
             elif n == 0:
-                LmTools.error("Internal error, unconsistent configuration - no mode")
+                LmUtils.error("Internal error, unconsistent configuration - no mode")
                 self.reject()
             else:
-                LmTools.log_debug(1, "Warning - no mode, defaulting to first")
+                LmUtils.log_debug(1, "Warning - no mode, defaulting to first")
                 selection = 0
 
         if selection >= 0:
@@ -496,7 +497,7 @@ class WifiConfigDialog(QtWidgets.QDialog):
         key = self._freq_combo.currentData()
         i = next((i for i in self._config["Intf"] if i["Key"] == key), None)
         if i is None:
-            LmTools.error(f"Internal error, unconsistent configuration - intf {key} not found")
+            LmUtils.error(f"Internal error, unconsistent configuration - intf {key} not found")
             self.reject()
         return key, i
 

--- a/src/LiveboxMonitor/tabs/LmActionsTab.py
+++ b/src/LiveboxMonitor/tabs/LmActionsTab.py
@@ -23,6 +23,7 @@ from LiveboxMonitor.dlg.LmBackupRestore import BackupRestoreDialog
 from LiveboxMonitor.dlg.LmScreen import ScreenDialog
 from LiveboxMonitor.dlg.LmCallApi import CallApiDialog
 from LiveboxMonitor.lang.LmLanguages import get_actions_label as lx, get_actions_message as mx
+from LiveboxMonitor.util import LmUtils
 
 from LiveboxMonitor.__init__ import __url__, __copyright__
 
@@ -494,7 +495,7 @@ class LmActions:
             try:
                 d = self._api._backup.get_status()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 auto_restore_enabled = False
             else:
                 auto_restore_enabled = d.get("Enable", False)
@@ -577,7 +578,7 @@ class LmActions:
         ipv4_ping = d.get("enableIPv4")
         ipv6_ping = d.get("enableIPv6")
         if (ipv4_ping is None) or (ipv6_ping is None):
-            LmTools.error("Cannot get respond to ping setup")
+            LmUtils.error("Cannot get respond to ping setup")
 
         ping_response_dialog = PingResponseDialog(ipv4_ping, ipv6_ping, self)
         if ping_response_dialog.exec():

--- a/src/LiveboxMonitor/tabs/LmDeviceInfoTab.py
+++ b/src/LiveboxMonitor/tabs/LmDeviceInfoTab.py
@@ -13,6 +13,7 @@ from LiveboxMonitor.tabs.LmInfoTab import InfoCol
 from LiveboxMonitor.dlg.LmDeviceName import SetDeviceNameDialog
 from LiveboxMonitor.dlg.LmDeviceType import SetDeviceTypeDialog
 from LiveboxMonitor.lang.LmLanguages import get_device_info_label as lx, get_device_info_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -270,26 +271,26 @@ class LmDeviceInfo:
             try:
                 d = self._api._device.get_info(device_key)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self._task.end()
                 self.display_error(mx("Error getting device information.", "devInfoErr"))
                 return
 
             i = 0
             i = self.add_info_line(self._info_alist, i, lx("Key"), device_key)
-            i = self.add_info_line(self._info_alist, i, lx("Active"), LmTools.fmt_bool(d.get("Active")))
-            i = self.add_info_line(self._info_alist, i, lx("Authenticated"), LmTools.fmt_bool(d.get("AuthenticationState")))
+            i = self.add_info_line(self._info_alist, i, lx("Active"), LmUtils.fmt_bool(d.get("Active")))
+            i = self.add_info_line(self._info_alist, i, lx("Authenticated"), LmUtils.fmt_bool(d.get("AuthenticationState")))
 
             try:
                 blocked = self._api._device.is_blocked(device_key)
-                i = self.add_info_line(self._info_alist, i, lx("Blocked"), LmTools.fmt_bool(blocked))
+                i = self.add_info_line(self._info_alist, i, lx("Blocked"), LmUtils.fmt_bool(blocked))
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(self._info_alist, i, lx("Blocked"), "Scheduler:getSchedule query error", LmTools.ValQual.Error)
 
-            i = self.add_info_line(self._info_alist, i, lx("First connection"), LmTools.fmt_livebox_timestamp(d.get("FirstSeen")))
-            i = self.add_info_line(self._info_alist, i, lx("Last connection"), LmTools.fmt_livebox_timestamp(d.get("LastConnection")))
-            i = self.add_info_line(self._info_alist, i, lx("Last changed"), LmTools.fmt_livebox_timestamp(d.get("LastChanged")))
+            i = self.add_info_line(self._info_alist, i, lx("First connection"), LmUtils.fmt_livebox_timestamp(d.get("FirstSeen")))
+            i = self.add_info_line(self._info_alist, i, lx("Last connection"), LmUtils.fmt_livebox_timestamp(d.get("LastConnection")))
+            i = self.add_info_line(self._info_alist, i, lx("Last changed"), LmUtils.fmt_livebox_timestamp(d.get("LastChanged")))
             i = self.add_info_line(self._info_alist, i, lx("Source"), d.get("DiscoverySource"))
 
             self._current_device_livebox_name = d.get("Name")
@@ -314,7 +315,7 @@ class LmDeviceInfo:
             for type in type_list:
                 i = self.add_info_line(self._info_alist, i, lx("Type"), f"{type.get('Type', '')} ({type.get('Source', '')})")
 
-            active_ip_struct = LmTools.determine_ip(d)
+            active_ip_struct = LmUtils.determine_ip(d)
             active_ip = active_ip_struct.get("Address", "") if active_ip_struct else ""
             ipv4_list = d.get("IPv4Address", [])
             for ipv4 in ipv4_list:
@@ -345,7 +346,7 @@ class LmDeviceInfo:
                     manufacturer = f"{details.get('companyName', '')} - {details.get('countryCode', '')}" if details else ""
                     i = self.add_info_line(self._info_alist, i, lx("Manufacturer"), manufacturer)
                 except Exception as e:
-                    LmTools.error(str(e))
+                    LmUtils.error(str(e))
                     i = self.add_info_line(self._info_alist, i, lx("Manufacturer"), "Web query error", LmTools.ValQual.Error)
 
             i = self.add_info_line(self._info_alist, i, lx("Vendor ID"), d.get("VendorClassID"))
@@ -362,14 +363,14 @@ class LmDeviceInfo:
                 i = self.add_info_line(self._info_alist, i, lx("State"), sys_software.get("State"))
                 i = self.add_info_line(self._info_alist, i, lx("Protocol"), sys_software.get("Protocol"))
                 i = self.add_info_line(self._info_alist, i, lx("Current Mode"), sys_software.get("CurrentMode"))
-                i = self.add_info_line(self._info_alist, i, lx("Pairing Time"), LmTools.fmt_livebox_timestamp(sys_software.get("PairingTime")))
+                i = self.add_info_line(self._info_alist, i, lx("Pairing Time"), LmUtils.fmt_livebox_timestamp(sys_software.get("PairingTime")))
                 i = self.add_info_line(self._info_alist, i, lx("Uplink Type"), sys_software.get("UplinkType"))
 
-            signal_strength = LmTools.fmt_int(d.get("SignalStrength"))
+            signal_strength = LmUtils.fmt_int(d.get("SignalStrength"))
             if len(signal_strength):
                 signal_strength += " dBm"
             i = self.add_info_line(self._info_alist, i, lx("Wifi Signal Strength"), signal_strength)
-            i = self.add_info_line(self._info_alist, i, lx("Wifi Signal Noise Ratio"), LmTools.fmt_int(d.get("SignalNoiseRatio")))
+            i = self.add_info_line(self._info_alist, i, lx("Wifi Signal Noise Ratio"), LmUtils.fmt_int(d.get("SignalNoiseRatio")))
             i = self.add_info_line(self._info_alist, i, lx("Encryption Mode"), d.get("EncryptionMode"))
             i = self.add_info_line(self._info_alist, i, lx("Security Mode"), d.get("SecurityModeEnabled"))
             i = self.add_info_line(self._info_alist, i, lx("Link Bandwidth"), d.get("LinkBandwidth"))
@@ -379,9 +380,9 @@ class LmDeviceInfo:
             sys_software_std = d.get("SSWSta")
             if sys_software_std is not None:
                 i = self.add_info_line(self._info_alist, i, lx("Supported Standards"), sys_software_std.get("SupportedStandards"))
-                i = self.add_info_line(self._info_alist, i, lx("Supports 2.4GHz"), LmTools.fmt_bool(sys_software_std.get("Supports24GHz")))
-                i = self.add_info_line(self._info_alist, i, lx("Supports 5GHz"), LmTools.fmt_bool(sys_software_std.get("Supports5GHz")))
-                i = self.add_info_line(self._info_alist, i, lx("Supports 6GHz"), LmTools.fmt_bool(sys_software_std.get("Supports6GHz")))
+                i = self.add_info_line(self._info_alist, i, lx("Supports 2.4GHz"), LmUtils.fmt_bool(sys_software_std.get("Supports24GHz")))
+                i = self.add_info_line(self._info_alist, i, lx("Supports 5GHz"), LmUtils.fmt_bool(sys_software_std.get("Supports5GHz")))
+                i = self.add_info_line(self._info_alist, i, lx("Supports 6GHz"), LmUtils.fmt_bool(sys_software_std.get("Supports6GHz")))
 
         finally:
             self._task.end()

--- a/src/LiveboxMonitor/tabs/LmDeviceListTab.py
+++ b/src/LiveboxMonitor/tabs/LmDeviceListTab.py
@@ -17,6 +17,7 @@ from LiveboxMonitor.tabs.LmRepeaterTab import INTF_NAME_MAP_WR
 from LiveboxMonitor.dlg.LmIPv6 import IPv6Dialog
 from LiveboxMonitor.dlg.LmDns import DnsDialog
 from LiveboxMonitor.lang.LmLanguages import get_device_list_label as lx, get_device_list_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -205,7 +206,7 @@ class LmDeviceList:
             try:
                 d = self._api._info.get_cgnat_status()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 cgnat = None
             else:
                 cgnat = d.get("Demand")
@@ -214,7 +215,7 @@ class LmDeviceList:
             try:
                 d = self._api._info.get_ipv6_mode()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 mode = None
             else:
                 mode = d.get("IPv6Mode")
@@ -223,7 +224,7 @@ class LmDeviceList:
             try:
                 d = self._api._info.get_wan_status()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 ipv6_addr = None
                 ipv6_prefix = None
                 gateway = None
@@ -280,7 +281,7 @@ class LmDeviceList:
             try:
                 self._livebox_devices = self._api._device.get_list()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Error getting device list.", "dlistErr"))
                 self._livebox_devices = None            
             else:
@@ -291,7 +292,7 @@ class LmDeviceList:
             try:
                 topology = self._api._device.get_topology()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Error getting device topology.", "topoErr"))
             else:
                 self.build_link_maps(topology)
@@ -367,7 +368,7 @@ class LmDeviceList:
         lb_name = QtWidgets.QTableWidgetItem(device.get("Name", ""))
         self._device_list.setItem(line, DevCol.LBName, lb_name)
 
-        ip_struct = LmTools.determine_ip(device)
+        ip_struct = LmUtils.determine_ip(device)
         if ip_struct is None:
             ipv4 = ""
             ipv4_reacheable = ""
@@ -565,7 +566,7 @@ class LmDeviceList:
                 try:
                     self._livebox_devices = self._api._device.get_list()
                 except Exception as e:
-                    LmTools.error(str(e))
+                    LmUtils.error(str(e))
                     self.display_error(mx("Error getting device list.", "dlistErr"))
                     return
 
@@ -593,7 +594,7 @@ class LmDeviceList:
             }
 
             # Map IPv4 address to device infos
-            ipv4_struct = LmTools.determine_ip(d)
+            ipv4_struct = LmUtils.determine_ip(d)
             if ipv4_struct:
                 ipv4 = ipv4_struct.get("Address", "")
                 if ipv4:
@@ -770,7 +771,7 @@ class LmDeviceList:
         up_rate_bytes = 0
         down_delta_errors = event.get("DeltaRxErrors", 0)
         up_delta_errors = event.get("DeltaTxErrors", 0)
-        timestamp = LmTools.livebox_timestamp(event.get("Timestamp", ""))
+        timestamp = LmUtils.livebox_timestamp(event.get("Timestamp", ""))
 
         # Try to find a previously received statistic record
         prev_stats = self._stats_map.get(device_key)
@@ -801,14 +802,14 @@ class LmDeviceList:
             # Prevent device line to change due to sorting
             self._device_list.setSortingEnabled(False)
 
-            down = NumericSortItem(LmTools.fmt_bytes(down_bytes))
+            down = NumericSortItem(LmUtils.fmt_bytes(down_bytes))
             down.setData(QtCore.Qt.ItemDataRole.UserRole, down_bytes)
             down.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
             if down_errors:
                 down.setForeground(QtCore.Qt.GlobalColor.red)
             self._device_list.setItem(list_line, DevCol.Down, down)
 
-            up = NumericSortItem(LmTools.fmt_bytes(up_bytes))
+            up = NumericSortItem(LmUtils.fmt_bytes(up_bytes))
             up.setData(QtCore.Qt.ItemDataRole.UserRole, up_bytes)
             up.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
             if up_errors:
@@ -816,7 +817,7 @@ class LmDeviceList:
             self._device_list.setItem(list_line, DevCol.Up, up)
 
             if down_rate_bytes:
-                down_rate = NumericSortItem(LmTools.fmt_bytes(down_rate_bytes) + "/s")
+                down_rate = NumericSortItem(LmUtils.fmt_bytes(down_rate_bytes) + "/s")
                 down_rate.setData(QtCore.Qt.ItemDataRole.UserRole, down_rate_bytes)
                 if down_delta_errors:
                     down_rate.setForeground(QtCore.Qt.GlobalColor.red)
@@ -826,7 +827,7 @@ class LmDeviceList:
             self._device_list.setItem(list_line, DevCol.DownRate, down_rate)
 
             if up_rate_bytes:
-                up_rate = NumericSortItem(LmTools.fmt_bytes(up_rate_bytes) + "/s")
+                up_rate = NumericSortItem(LmUtils.fmt_bytes(up_rate_bytes) + "/s")
                 up_rate.setData(QtCore.Qt.ItemDataRole.UserRole, up_rate_bytes)
                 if up_delta_errors:
                     up_rate.setForeground(QtCore.Qt.GlobalColor.red)
@@ -882,7 +883,7 @@ class LmDeviceList:
 
             # Check if IPv4 changed
             ipv4 = event.get("IPAddress")
-            if (ipv4 is not None) and (LmTools.is_ipv4(ipv4)):
+            if (ipv4 is not None) and (LmUtils.is_ipv4(ipv4)):
                 self._device_ip_name_map_dirty = True
                 ip = self._device_list.item(list_line, DevCol.IP)
                 ip.setText(ipv4)
@@ -982,14 +983,14 @@ class LmDeviceList:
                 try:
                     curr_ip = self._api._device.get_ip_addr(device_key)
                 except Exception as e:
-                    LmTools.error(str(e))
+                    LmUtils.error(str(e))
                     curr_ip = known_ip
 
                 # Proceed only if there is a change
                 if known_ip != curr_ip:
                     # If current IP is the one of the event, take it, overwise wait for next device update event
                     ipv4 = event.get("Address", "")
-                    if LmTools.is_ipv4(ipv4) and (curr_ip == ipv4):
+                    if LmUtils.is_ipv4(ipv4) and (curr_ip == ipv4):
                         ipv4_reacheable = event.get("Status", "")
                         ipv4_reserved = event.get("Reserved", False)
                         ip = self.format_ipv4_table_widget(ipv4, ipv4_reacheable, ipv4_reserved)
@@ -1115,7 +1116,7 @@ class LmDeviceList:
             self._device_list.setSortingEnabled(False)
 
             if down_rate_bytes:
-                down_rate = NumericSortItem(LmTools.fmt_bytes(down_rate_bytes) + "/s")
+                down_rate = NumericSortItem(LmUtils.fmt_bytes(down_rate_bytes) + "/s")
                 down_rate.setData(QtCore.Qt.ItemDataRole.UserRole, down_rate_bytes)
                 if down_delta_errors:
                     down_rate.setForeground(QtCore.Qt.GlobalColor.red)
@@ -1127,7 +1128,7 @@ class LmDeviceList:
             self._device_list.setItem(list_line, DevCol.DownRate, down_rate)
 
             if up_rate_bytes:
-                up_rate = NumericSortItem(LmTools.fmt_bytes(up_rate_bytes) + "/s")
+                up_rate = NumericSortItem(LmUtils.fmt_bytes(up_rate_bytes) + "/s")
                 up_rate.setData(QtCore.Qt.ItemDataRole.UserRole, up_rate_bytes)
                 if up_delta_errors:
                     up_rate.setForeground(QtCore.Qt.GlobalColor.red)
@@ -1164,7 +1165,7 @@ class LiveboxWifiStatsThread(LmThread):
             try:
                 d = self._api._stats.get_wifi_intf(s["Key"])
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
             else:
                 if isinstance(d, list):
                     for stat in d:

--- a/src/LiveboxMonitor/tabs/LmDhcpTab.py
+++ b/src/LiveboxMonitor/tabs/LmDhcpTab.py
@@ -13,6 +13,7 @@ from LiveboxMonitor.tabs.LmInfoTab import InfoCol
 from LiveboxMonitor.dlg.LmDhcpBinding import AddDhcpBindingDialog
 from LiveboxMonitor.dlg.LmDhcpSetup import DhcpSetupDialog
 from LiveboxMonitor.lang.LmLanguages import get_dhcp_label as lx, get_dhcp_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -245,7 +246,7 @@ class LmDhcp:
                 try:
                     network = IPv4Network(f"{i[0]}.{i[1]}.{i[2]}.0/{new_dhcp_mask}")
                 except Exception as e:
-                    LmTools.error(str(e))
+                    LmUtils.error(str(e))
                     self.display_error(mx("Wrong values. Error: {}", "dhcpValErr").format(e))
                     return
                 new_dhcp_prefix_len = network.prefixlen
@@ -272,7 +273,7 @@ class LmDhcp:
             try:
                 d = self._api._dhcp.get_leases()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 d = None
             self.load_dhcp_bindings_in_list(d, "Home")
 
@@ -280,7 +281,7 @@ class LmDhcp:
             try:
                 d = self._api._dhcp.get_leases(True)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 d = None
             self.load_dhcp_bindings_in_list(d, "Guest")
 
@@ -352,7 +353,7 @@ class LmDhcp:
             mask = self._guest_ip_mask
 
         # Set network
-        if LmTools.is_ipv4(server):
+        if LmUtils.is_ipv4(server):
             i = server.split(".")
             try:
                 return IPv4Network(f"{i[0]}.{i[1]}.{i[2]}.0/{mask}")
@@ -373,13 +374,13 @@ class LmDhcp:
             try:
                 d = self._api._dhcp.get_info()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 d = None
             if d:
                 g = d.get("guest")
                 d = d.get("default")
             if d:
-                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Enabled"), LmTools.fmt_bool(d.get("Enable")))
+                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Enabled"), LmUtils.fmt_bool(d.get("Enable")))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Status"), d.get("Status"))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Gateway"), d.get("Server"))
                 self._home_ip_server = d.get("Server")
@@ -388,7 +389,7 @@ class LmDhcp:
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Start"), d.get("MinAddress"))
                 self._home_ip_start = d.get("MinAddress")
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 End"), d.get("MaxAddress"))
-                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Lease Time"), LmTools.fmt_time(d.get("LeaseTime")))
+                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Lease Time"), LmUtils.fmt_time(d.get("LeaseTime")))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DNS Servers"), d.get("DNSServers"))
             else:
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4"), "DHCPv4.Server:getDHCPServerPool query error", LmTools.ValQual.Error)
@@ -396,7 +397,7 @@ class LmDhcp:
             try:
                 d = self._api._dhcp.get_v6_server_status()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv6"), "DHCPv6.Server:getDHCPv6ServerStatus query error", LmTools.ValQual.Error)
             else:
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv6 Status"), d)
@@ -404,7 +405,7 @@ class LmDhcp:
             try:
                 d = self._api._dhcp.get_v6_prefix()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv6"), "DHCPv6.Server:getPDPrefixInformation query error", LmTools.ValQual.Error)
             else:
                 if d:
@@ -419,7 +420,7 @@ class LmDhcp:
             if g is not None:
                 i = self.add_title_line(self._dhcp_alist, i, lx("DHCP Guest Information"))
 
-                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Enabled"), LmTools.fmt_bool(g.get("Enable")))
+                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Enabled"), LmUtils.fmt_bool(g.get("Enable")))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Status"), g.get("Status"))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Gateway"), g.get("Server"))
                 self._guest_ip_server = g.get("Server")
@@ -428,7 +429,7 @@ class LmDhcp:
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Start"), g.get("MinAddress"))
                 self._guest_ip_start = g.get("MinAddress")
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 End"), g.get("MaxAddress"))
-                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Lease Time"), LmTools.fmt_time(g.get("LeaseTime")))
+                i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4 Lease Time"), LmUtils.fmt_time(g.get("LeaseTime")))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DNS Servers"), g.get("DNSServers"))
 
 
@@ -438,7 +439,7 @@ class LmDhcp:
             try:
                 d = self._api._dhcp.get_mibs(True, True)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(self._dhcp_alist, i, lx("DHCPv4"), "NeMo.Intf.data:getMIBs query error", LmTools.ValQual.Error)
             else:
                 p = d.get("dhcp")
@@ -447,9 +448,9 @@ class LmDhcp:
                     p = p.get("dhcp_data")
                 if p is not None:
                     i = self.add_info_line(self._dhcp_alist, i, lx("Status"), p.get("DHCPStatus"))
-                    i = self.add_info_line(self._dhcp_alist, i, lx("Lease Time"), LmTools.fmt_time(p.get("LeaseTime")))
-                    i = self.add_info_line(self._dhcp_alist, i, lx("Lease Time Remaining"), LmTools.fmt_time(p.get("LeaseTimeRemaining")))
-                    i = self.add_info_line(self._dhcp_alist, i, lx("Check Authentication"), LmTools.fmt_bool(p.get("CheckAuthentication")))
+                    i = self.add_info_line(self._dhcp_alist, i, lx("Lease Time"), LmUtils.fmt_time(p.get("LeaseTime")))
+                    i = self.add_info_line(self._dhcp_alist, i, lx("Lease Time Remaining"), LmUtils.fmt_time(p.get("LeaseTimeRemaining")))
+                    i = self.add_info_line(self._dhcp_alist, i, lx("Check Authentication"), LmUtils.fmt_bool(p.get("CheckAuthentication")))
                     i = self.add_info_line(self._dhcp_alist, i, lx("Authentication Information"), p.get("AuthenticationInformation"))
                     i = self.load_dhcp_info_options(lx("DHCPv4 Sent Options"), i, p.get("SentOption"))
                     i = self.load_dhcp_info_options(lx("DHCPv4 Received Options"), i, p.get("ReqOption"))
@@ -464,10 +465,10 @@ class LmDhcp:
                 if p is not None:
                     i = self.add_info_line(self._dhcp_alist, i, lx("Status"), p.get("DHCPStatus"))
                     i = self.add_info_line(self._dhcp_alist, i, lx("DUID"), p.get("DUID"))
-                    i = self.add_info_line(self._dhcp_alist, i, lx("Request Addresses"), LmTools.fmt_bool(p.get("RequestAddresses")))
-                    i = self.add_info_line(self._dhcp_alist, i, lx("Request Prefixes"), LmTools.fmt_bool(p.get("RequestPrefixes")))
+                    i = self.add_info_line(self._dhcp_alist, i, lx("Request Addresses"), LmUtils.fmt_bool(p.get("RequestAddresses")))
+                    i = self.add_info_line(self._dhcp_alist, i, lx("Request Prefixes"), LmUtils.fmt_bool(p.get("RequestPrefixes")))
                     i = self.add_info_line(self._dhcp_alist, i, lx("Requested Options"), p.get("RequestedOptions"))
-                    i = self.add_info_line(self._dhcp_alist, i, lx("Check Authentication"), LmTools.fmt_bool(p.get("CheckAuthentication")))
+                    i = self.add_info_line(self._dhcp_alist, i, lx("Check Authentication"), LmUtils.fmt_bool(p.get("CheckAuthentication")))
                     i = self.add_info_line(self._dhcp_alist, i, lx("Authentication Information"), p.get("AuthenticationInfo"))
                     i = self.load_dhcp_info_options(lx("DHCPv6 Sent Options"), i, p.get("SentOption"))
                     i = self.load_dhcp_info_options(lx("DHCPv6 Received Options"), i, p.get("ReceivedOption"))

--- a/src/LiveboxMonitor/tabs/LmEventsTab.py
+++ b/src/LiveboxMonitor/tabs/LmEventsTab.py
@@ -17,6 +17,7 @@ from LiveboxMonitor.app.LmTableWidget import LmTableWidget
 from LiveboxMonitor.tabs.LmDeviceListTab import DSelCol
 from LiveboxMonitor.dlg.LmNotificationSetup import NotificationSetupDialog
 from LiveboxMonitor.lang.LmLanguages import get_events_label as lx, get_events_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -265,7 +266,7 @@ class LmEvents:
             a = None
 
         # Try to guess device key from handler
-        device_key = LmTools.extract_mac_addr_from_string(h)
+        device_key = LmUtils.extract_mac_addr_from_string(h)
         if len(device_key):
             self.update_event_indicator(device_key)
             if r == "Statistics":
@@ -400,15 +401,15 @@ class LmEvents:
         t = event["Type"]
 
         ### Debug logs
-        if LmTools.get_verbosity() >= 1:
+        if LmUtils.get_verbosity() >= 1:
             ts = event["Timestamp"].strftime("%d/%m/%Y - %H:%M:%S")
             k = event["Key"]
             if t == LmNotif.TYPE_ACTIVE:
-                LmTools.log_debug(1, f"RAW EVT = {ts} - {k} DEV {t} -> {event['Link']}.")
+                LmUtils.log_debug(1, f"RAW EVT = {ts} - {k} DEV {t} -> {event['Link']}.")
             elif t == LmNotif.TYPE_LINK_CHANGE:
-                LmTools.log_debug(1, f"RAW EVT = {ts} - {k} DEV {t} -> from {event['OldLink']} to {event['NewLink']}.")
+                LmUtils.log_debug(1, f"RAW EVT = {ts} - {k} DEV {t} -> from {event['OldLink']} to {event['NewLink']}.")
             else:
-                LmTools.log_debug(1, f"RAW EVT = {ts} - {k} DEV {t}.")
+                LmUtils.log_debug(1, f"RAW EVT = {ts} - {k} DEV {t}.")
 
         # If DELETE event look for a recent DELETE event, if too close (duplicates) don't add
         match t:
@@ -508,7 +509,7 @@ class LmEvents:
 
     ### Generate a user notification for an event in a CSV file
     def notify_user_file(self, event):
-        LmTools.log_debug(1, "Logging event in file:", str(event))
+        LmUtils.log_debug(1, "Logging event in file:", str(event))
 
         k = event["Key"]
         n = LmConf.MacAddrTable.get(k, lx("### UNKNOWN ###"))
@@ -539,16 +540,16 @@ class LmEvents:
                 csv_writer = csv.writer(f, dialect = "excel", delimiter = LmConf.CsvDelimiter)
                 csv_writer.writerow(r)
         except Exception as e:
-            LmTools.error(f"Cannot log event. Error: {e}")
+            LmUtils.error(f"Cannot log event. Error: {e}")
 
 
     ### Generate a user notification for an event via configured email
     def notify_user_email(self, event):
-        LmTools.log_debug(1, "Emailing event:", str(event))
+        LmUtils.log_debug(1, "Emailing event:", str(event))
 
         c = LmConf.load_email_setup()
         if c is None:
-            LmTools.error("No email setup to notify event by email.")
+            LmUtils.error("No email setup to notify event by email.")
             return
 
         k = event["Key"]
@@ -635,7 +636,7 @@ class LiveboxEventThread(LmThread):
         if d:
             if d.get("errors"):
                 # Session has probably timed out on Livebox side, resign
-                LmTools.log_debug(1, "Errors in event request, resign")
+                LmUtils.log_debug(1, "Errors in event request, resign")
                 if self._session.signin(LmConf.LiveboxUser, LmConf.LiveboxPassword) <= 0:
                     time.sleep(1)  # Avoid looping too quickly in case LB is unreachable
             elif d.get("error"):

--- a/src/LiveboxMonitor/tabs/LmGraphTab.py
+++ b/src/LiveboxMonitor/tabs/LmGraphTab.py
@@ -13,6 +13,7 @@ from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget
 from LiveboxMonitor.dlg.LmAddGraph import AddGraphDialog, GraphType
 from LiveboxMonitor.lang.LmLanguages import get_graph_label as lx, get_graph_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -295,7 +296,7 @@ class LmGraph:
                 suffix = "_" + str(n)
                 continue
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Cannot create the file.", "createFileErr"))
                 return
             break
@@ -321,7 +322,7 @@ class LmGraph:
             try:
                 export_file.close()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Cannot save the file.", "saveFileErr"))
 
 

--- a/src/LiveboxMonitor/tabs/LmInfoTab.py
+++ b/src/LiveboxMonitor/tabs/LmInfoTab.py
@@ -11,6 +11,7 @@ from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.app.LmThread import LmThread
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget
 from LiveboxMonitor.lang.LmLanguages import get_info_label as lx, get_info_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -303,14 +304,14 @@ class LmInfo:
         list_line = self.find_stats_line(key)
         if list_line >= 0:
             if down_bytes is not None:
-                down = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(down_bytes))
+                down = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(down_bytes))
                 down.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
                 if down_errors:
                     down.setForeground(QtCore.Qt.GlobalColor.red)
                 self._stats_list.setItem(list_line, StatsCol.Down, down)
 
             if up_bytes is not None:
-                up = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(up_bytes))
+                up = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(up_bytes))
                 up.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
                 if up_errors:
                     up.setForeground(QtCore.Qt.GlobalColor.red)
@@ -318,7 +319,7 @@ class LmInfo:
 
             if source == "nds":
                 if down_rate_bytes:
-                    down_rate = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(down_rate_bytes) + "/s")
+                    down_rate = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(down_rate_bytes) + "/s")
                     if down_delta_errors:
                         down_rate.setForeground(QtCore.Qt.GlobalColor.red)
                     down_rate.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
@@ -327,7 +328,7 @@ class LmInfo:
                 self._stats_list.setItem(list_line, StatsCol.DownRate, down_rate)
 
                 if up_rate_bytes:
-                    up_rate = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(up_rate_bytes) + "/s")
+                    up_rate = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(up_rate_bytes) + "/s")
                     if up_delta_errors:
                         up_rate.setForeground(QtCore.Qt.GlobalColor.red)
                     up_rate.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
@@ -507,7 +508,7 @@ class LmInfo:
         try:
             self._export_file = open(file_name, "w")
         except Exception as e:
-            LmTools.error(f"File creation error: {e}")
+            LmUtils.error(f"File creation error: {e}")
             self.display_error(mx("Cannot create the file.", "createFileErr"))
             return
 
@@ -531,7 +532,7 @@ class LmInfo:
             try:
                 self._export_file.close()
             except Exception as e:
-                LmTools.error(f"File saving error: {e}")
+                LmUtils.error(f"File saving error: {e}")
                 self.display_error(mx("Cannot save the file.", "saveFileErr"))
 
             self._export_file = None
@@ -544,7 +545,7 @@ class LmInfo:
         try:
             d = self._api._info.get_model_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Livebox Infos"), "UPnP-IGD:get query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Provider"), d.get("WANAccessProvider"))
@@ -556,7 +557,7 @@ class LmInfo:
         try:
             d = self._api._reboot.get_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Livebox Infos"), "NMC.Reboot:get query error", LmTools.ValQual.Error)
             total_reboot = None
         else:
@@ -565,12 +566,12 @@ class LmInfo:
         try:
             d = self._api._info.get_device_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Livebox Infos"), "DeviceInfo:get query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Model"), d.get("ProductClass"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Status"), LmTools.fmt_str_capitalize(d.get("DeviceStatus")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Livebox Up Time"), LmTools.fmt_time(d.get("UpTime")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Status"), LmUtils.fmt_str_capitalize(d.get("DeviceStatus")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Livebox Up Time"), LmUtils.fmt_time(d.get("UpTime")))
             i = self.add_info_line(self._livebox_alist, i, lx("Manufacturer"), d.get("Manufacturer"))
             i = self.add_info_line(self._livebox_alist, i, lx("Manufacturer Model Name"), d.get("ModelName"))
             i = self.add_info_line(self._livebox_alist, i, lx("Description"), d.get("Description"))
@@ -582,35 +583,35 @@ class LmInfo:
             i = self.add_info_line(self._livebox_alist, i, lx("Orange Firmware Version"), d.get("AdditionalSoftwareVersion"))
             i = self.add_info_line(self._livebox_alist, i, lx("Spec Version"), d.get("SpecVersion"))
             i = self.add_info_line(self._livebox_alist, i, lx("Provisioning Code"), d.get("ProvisioningCode"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Country"), LmTools.fmt_str_upper(d.get("Country")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Country"), LmUtils.fmt_str_upper(d.get("Country")))
             i = self.add_info_line(self._livebox_alist, i, lx("MAC Address"), self._api._info.get_mac())
             i = self.add_info_line(self._livebox_alist, i, lx("External IP Address"), d.get("ExternalIPAddress"))
             if total_reboot is not None:
-                i = self.add_info_line(self._livebox_alist, i, lx("Total Number Of Reboots"), LmTools.fmt_int(total_reboot))
-            i = self.add_info_line(self._livebox_alist, i, lx("Number Of Reboots"), LmTools.fmt_int(d.get("NumberOfReboots")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Upgrade Occurred"), LmTools.fmt_bool(d.get("UpgradeOccurred")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Reset Occurred"), LmTools.fmt_bool(d.get("ResetOccurred")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Restore Occurred"), LmTools.fmt_bool(d.get("RestoreOccurred")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Total Number Of Reboots"), LmUtils.fmt_int(total_reboot))
+            i = self.add_info_line(self._livebox_alist, i, lx("Number Of Reboots"), LmUtils.fmt_int(d.get("NumberOfReboots")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Upgrade Occurred"), LmUtils.fmt_bool(d.get("UpgradeOccurred")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Reset Occurred"), LmUtils.fmt_bool(d.get("ResetOccurred")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Restore Occurred"), LmUtils.fmt_bool(d.get("RestoreOccurred")))
 
         try:
             d = self._api._info.get_device_config()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Livebox Infos"), "Devices.Device:get query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Name"), d.get("Name"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(d.get("Active")))
-            i = self.add_info_line(self._livebox_alist, i, lx("First Boot"), LmTools.fmt_livebox_timestamp(d.get("FirstSeen")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(d.get("Active")))
+            i = self.add_info_line(self._livebox_alist, i, lx("First Boot"), LmUtils.fmt_livebox_timestamp(d.get("FirstSeen")))
             i = self.add_info_line(self._livebox_alist, i, lx("Boot Loader Version"), d.get("BootLoaderVersion"))
             i = self.add_info_line(self._livebox_alist, i, lx("Firewall Level"), d.get("FirewallLevel"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Internet Active"), LmTools.fmt_bool(d.get("Internet")))
-            i = self.add_info_line(self._livebox_alist, i, lx("IPTV Active"), LmTools.fmt_bool(d.get("IPTV")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Telephony Active"), LmTools.fmt_bool(d.get("Telephony")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Internet Active"), LmUtils.fmt_bool(d.get("Internet")))
+            i = self.add_info_line(self._livebox_alist, i, lx("IPTV Active"), LmUtils.fmt_bool(d.get("IPTV")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Telephony Active"), LmUtils.fmt_bool(d.get("Telephony")))
 
         try:
             d = self._api._info.get_time()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Time"), "Time:getTime query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Time"), d.get("time"))
@@ -618,11 +619,11 @@ class LmInfo:
         try:
             d = self._api._info.get_memory_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Memory"), "DeviceInfo.MemoryStatus:get query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("Total Memory"), LmTools.fmt_int(d.get("Total")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Free Memory"), LmTools.fmt_int(d.get("Free")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Total Memory"), LmUtils.fmt_int(d.get("Total")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Free Memory"), LmUtils.fmt_int(d.get("Free")))
 
         return i
 
@@ -634,7 +635,7 @@ class LmInfo:
         try:
             d = self._api._info.get_connection_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Connection"), "NMC:get query error", LmTools.ValQual.Error)
         else:
             access_type = d.get("WanMode")
@@ -645,8 +646,8 @@ class LmInfo:
                     i = self.add_info_line(self._livebox_alist, i, lx("Access Type"), f"ADSL ({access_type})")
 
             i = self.add_info_line(self._livebox_alist, i, lx("Username"), d.get("Username"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Factory Reset Scheduled"), LmTools.fmt_bool(d.get("FactoryResetScheduled")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Connection Error"), LmTools.fmt_bool(d.get("ConnectionError")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Factory Reset Scheduled"), LmUtils.fmt_bool(d.get("FactoryResetScheduled")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Connection Error"), LmUtils.fmt_bool(d.get("ConnectionError")))
             i = self.add_info_line(self._livebox_alist, i, lx("Offer Type"), d.get("OfferType"))
             i = self.add_info_line(self._livebox_alist, i, lx("Offer Name"), d.get("OfferName"))
             i = self.add_info_line(self._livebox_alist, i, lx("IPTV Mode"), d.get("IPTVMode"))
@@ -654,13 +655,13 @@ class LmInfo:
         try:
             d = self._api._info.get_wan_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Internet Infos"), "NMC:getWANStatus query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("WAN Status"), LmTools.fmt_str_capitalize(d.get("WanState")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Link Status"), LmTools.fmt_str_capitalize(d.get("LinkState")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Link Type"), LmTools.fmt_str_upper(d.get("LinkType")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Protocol"), LmTools.fmt_str_upper(d.get("Protocol")))
+            i = self.add_info_line(self._livebox_alist, i, lx("WAN Status"), LmUtils.fmt_str_capitalize(d.get("WanState")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Link Status"), LmUtils.fmt_str_capitalize(d.get("LinkState")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Link Type"), LmUtils.fmt_str_upper(d.get("LinkType")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Protocol"), LmUtils.fmt_str_upper(d.get("Protocol")))
             i = self.add_info_line(self._livebox_alist, i, lx("GPON State"), d.get("GponState"))
             i = self.add_info_line(self._livebox_alist, i, lx("Connection Status"), d.get("ConnectionState"))
             i = self.add_info_line(self._livebox_alist, i, lx("Last Connection Error"), d.get("LastConnectionError"))
@@ -673,24 +674,24 @@ class LmInfo:
         try:
             d = self._api._info.get_device_config()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Internet Infos"), "Devices.Device:get query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("Last Connection"), LmTools.fmt_livebox_timestamp(d.get("LastConnection")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Last Connection"), LmUtils.fmt_livebox_timestamp(d.get("LastConnection")))
             i = self.add_info_line(self._livebox_alist, i, lx("Firewall Level"), d.get("FirewallLevel"))
             rate = d.get("DownstreamMaxBitRate")
             if rate is not None:
                 rate *= 1048576
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Down Bit Rate"), LmTools.fmt_bytes(rate))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Down Bit Rate"), LmUtils.fmt_bytes(rate))
             rate = d.get("UpstreamMaxBitRate")
             if rate is not None:
                 rate *= 1048576
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Up Bit Rate"), LmTools.fmt_bytes(rate))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Up Bit Rate"), LmUtils.fmt_bytes(rate))
 
         try:
             d = self._api._dhcp.get_mibs(True, False)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             d = None
         if d is not None:
             d = d.get("dhcp")
@@ -703,28 +704,28 @@ class LmInfo:
             i = self.add_info_line(self._livebox_alist, i, lx("Subnet Mask"), d.get("SubnetMask"))
             i = self.add_info_line(self._livebox_alist, i, lx("IP Routers"), d.get("IPRouters"))
             i = self.add_info_line(self._livebox_alist, i, lx("DHCP Server"), d.get("DHCPServer"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Renew"), LmTools.fmt_bool(d.get("Renew")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Authentication"), LmTools.fmt_bool(d.get("CheckAuthentication")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Renew"), LmUtils.fmt_bool(d.get("Renew")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Authentication"), LmUtils.fmt_bool(d.get("CheckAuthentication")))
             i = self.add_info_line(self._livebox_alist, i, lx("Authentication Information"), d.get("AuthenticationInformation"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Connection Up Time"), LmTools.fmt_time(d.get("Uptime")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Lease Time"), LmTools.fmt_time(d.get("LeaseTime")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Lease Time Remaining"), LmTools.fmt_time(d.get("LeaseTimeRemaining")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Connection Up Time"), LmUtils.fmt_time(d.get("Uptime")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Lease Time"), LmUtils.fmt_time(d.get("LeaseTime")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Lease Time Remaining"), LmUtils.fmt_time(d.get("LeaseTimeRemaining")))
 
         try:
             d = self._api._info.get_vlan_id()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("VLAN ID"), "NeMo.Intf.data:getFirstParameter query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("VLAN ID"), LmTools.fmt_int(d))
+            i = self.add_info_line(self._livebox_alist, i, lx("VLAN ID"), LmUtils.fmt_int(d))
 
         try:
             d = self._api._info.get_mtu()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("MTU"), "NeMo.Intf.data:getFirstParameter query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("MTU"), LmTools.fmt_int(d))
+            i = self.add_info_line(self._livebox_alist, i, lx("MTU"), LmUtils.fmt_int(d))
 
         return i
 
@@ -738,42 +739,42 @@ class LmInfo:
         try:
             d = self._api._wifi.get_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Wifi"), "NMC.Wifi:get query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmTools.fmt_bool(d.get("Enable")))
-            i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(d.get("Status")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmUtils.fmt_bool(d.get("Enable")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(d.get("Status")))
             i = self.add_info_line(self._livebox_alist, i, lx("BGN User Bandwidth"), d.get("BGNUserBandwidth"))
 
         # Wifi scheduler
         try:
             d = self._api._wifi.get_scheduler_enable()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Scheduler Enabled"), "Scheduler query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("Scheduler Enabled"), LmTools.fmt_bool(d))
+            i = self.add_info_line(self._livebox_alist, i, lx("Scheduler Enabled"), LmUtils.fmt_bool(d))
 
         # Wifi 7 MLO
         if self._api._wifi.has_mlo():
             try:
                 d = self._api._wifi.get_mlo_config()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(self._livebox_alist, i, lx("MLO"), "MLO query error", LmTools.ValQual.Error)
             else:
-                i = self.add_info_line(self._livebox_alist, i, lx("MLO"), LmTools.fmt_bool(d.get("MLOEnable")))
-                i = self.add_info_line(self._livebox_alist, i, lx("MLO Single MLD Unit"), LmTools.fmt_int(d.get("SingleMLDUnit")))
-                i = self.add_info_line(self._livebox_alist, i, lx("MLO EMLSR"), LmTools.fmt_bool(d.get("EMLSREnable")))
-                i = self.add_info_line(self._livebox_alist, i, lx("MLO EMLMR"), LmTools.fmt_bool(d.get("EMLMREnable")))
-                i = self.add_info_line(self._livebox_alist, i, lx("MLO STR"), LmTools.fmt_bool(d.get("STREnable")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MLO"), LmUtils.fmt_bool(d.get("MLOEnable")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MLO Single MLD Unit"), LmUtils.fmt_int(d.get("SingleMLDUnit")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MLO EMLSR"), LmUtils.fmt_bool(d.get("EMLSREnable")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MLO EMLMR"), LmUtils.fmt_bool(d.get("EMLMREnable")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MLO STR"), LmUtils.fmt_bool(d.get("STREnable")))
                 i = self.add_info_line(self._livebox_alist, i, lx("MLO Split MLD Mode"), d.get("SplitMLDMode"))
 
         # Wifi interfaces
         try:
             b, w, d = self._api._intf.get_wifi_mibs()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Wifi"), "NeMo.Intf.lan:getMIBs query error", LmTools.ValQual.Error)
         else:
             for s in intf_list:
@@ -785,8 +786,8 @@ class LmInfo:
                 intf_key = None
                 base = b.get(s["Key"])
                 if base is not None:
-                    i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmTools.fmt_bool(base.get("Enable")))
-                    i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(base.get("Status")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmUtils.fmt_bool(base.get("Enable")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(base.get("Status")))
                     low_level_intf = base.get("LLIntf")
                     if low_level_intf is not None:
                         intf_key = next(iter(low_level_intf))
@@ -798,10 +799,10 @@ class LmInfo:
 
                 i = self.add_info_line(self._livebox_alist, i, lx("Radio Status"), q.get("RadioStatus"))
                 i = self.add_info_line(self._livebox_alist, i, lx("VAP Status"), r.get("VAPStatus"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Vendor Name"), LmTools.fmt_str_upper(q.get("VendorName")))
-                i = self.add_info_line(self._livebox_alist, i, lx("MAC Address"), LmTools.fmt_str_upper(r.get("MACAddress")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Vendor Name"), LmUtils.fmt_str_upper(q.get("VendorName")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MAC Address"), LmUtils.fmt_str_upper(r.get("MACAddress")))
                 i = self.add_info_line(self._livebox_alist, i, lx("SSID"), r.get("SSID"))
-                i = self.add_info_line(self._livebox_alist, i, lx("SSID Advertisement"), LmTools.fmt_bool(r.get("SSIDAdvertisementEnabled")))
+                i = self.add_info_line(self._livebox_alist, i, lx("SSID Advertisement"), LmUtils.fmt_bool(r.get("SSIDAdvertisementEnabled")))
 
                 t = r.get("Security")
                 if t is not None:
@@ -812,36 +813,36 @@ class LmInfo:
 
                 t = r.get("WPS")
                 if t is not None:
-                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Enabled"), LmTools.fmt_bool(t.get("Enable")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Enabled"), LmUtils.fmt_bool(t.get("Enable")))
                     i = self.add_info_line(self._livebox_alist, i, lx("WPS Methods"), t.get("ConfigMethodsEnabled"))
                     i = self.add_info_line(self._livebox_alist, i, lx("WPS Self PIN"), t.get("SelfPIN"))
-                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Pairing In Progress"), LmTools.fmt_bool(t.get("PairingInProgress")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Pairing In Progress"), LmUtils.fmt_bool(t.get("PairingInProgress")))
 
                 t = r.get("MACFiltering")
                 if t is not None:
                     i = self.add_info_line(self._livebox_alist, i, lx("MAC Filtering"), t.get("Mode"))
 
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Bitrate"), LmTools.fmt_int(q.get("MaxBitRate")))
-                i = self.add_info_line(self._livebox_alist, i, lx("AP Mode"), LmTools.fmt_bool(q.get("AP_Mode")))
-                i = self.add_info_line(self._livebox_alist, i, lx("STA Mode"), LmTools.fmt_bool(q.get("STA_Mode")))
-                i = self.add_info_line(self._livebox_alist, i, lx("WDS Mode"), LmTools.fmt_bool(q.get("WDS_Mode")))
-                i = self.add_info_line(self._livebox_alist, i, lx("WET Mode"), LmTools.fmt_bool(q.get("WET_Mode")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Bitrate"), LmUtils.fmt_int(q.get("MaxBitRate")))
+                i = self.add_info_line(self._livebox_alist, i, lx("AP Mode"), LmUtils.fmt_bool(q.get("AP_Mode")))
+                i = self.add_info_line(self._livebox_alist, i, lx("STA Mode"), LmUtils.fmt_bool(q.get("STA_Mode")))
+                i = self.add_info_line(self._livebox_alist, i, lx("WDS Mode"), LmUtils.fmt_bool(q.get("WDS_Mode")))
+                i = self.add_info_line(self._livebox_alist, i, lx("WET Mode"), LmUtils.fmt_bool(q.get("WET_Mode")))
                 i = self.add_info_line(self._livebox_alist, i, lx("Frequency Band"), q.get("OperatingFrequencyBand"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Channel Bandwidth"), q.get("CurrentOperatingChannelBandwidth"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Standard"), q.get("OperatingStandards"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Channel"), LmTools.fmt_int(q.get("Channel")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Auto Channel Supported"), LmTools.fmt_bool(q.get("AutoChannelSupported")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Auto Channel Enabled"), LmTools.fmt_bool(q.get("AutoChannelEnable")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Channel"), LmUtils.fmt_int(q.get("Channel")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Auto Channel Supported"), LmUtils.fmt_bool(q.get("AutoChannelSupported")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Auto Channel Enabled"), LmUtils.fmt_bool(q.get("AutoChannelEnable")))
                 i = self.add_info_line(self._livebox_alist, i, lx("Channel Change Reason"), q.get("ChannelChangeReason"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Associated Devices"), LmTools.fmt_int(q.get("MaxAssociatedDevices")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Active Associated Devices"), LmTools.fmt_int(q.get("ActiveAssociatedDevices")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Noise"), LmTools.fmt_int(q.get("Noise")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Antenna Defect"), LmTools.fmt_bool(q.get("AntennaDefect")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Associated Devices"), LmUtils.fmt_int(q.get("MaxAssociatedDevices")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Active Associated Devices"), LmUtils.fmt_int(q.get("ActiveAssociatedDevices")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Noise"), LmUtils.fmt_int(q.get("Noise")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Antenna Defect"), LmUtils.fmt_bool(q.get("AntennaDefect")))
 
         try:
             b, w, d = self._api._intf.get_wifi_mibs(True)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Wifi"), "NeMo.Intf.guest:getMIBs query error", LmTools.ValQual.Error)
         else:
             for s in intf_list:
@@ -851,17 +852,17 @@ class LmInfo:
 
                 base = b.get(s["Key"])
                 if base is not None:
-                    i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmTools.fmt_bool(base.get("Enable")))
-                    i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(base.get("Status")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmUtils.fmt_bool(base.get("Enable")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(base.get("Status")))
 
                 r = d.get(s["Key"])
                 if r is None:
                     continue
 
                 i = self.add_info_line(self._livebox_alist, i, lx("VAP Status"), r.get("VAPStatus"))
-                i = self.add_info_line(self._livebox_alist, i, lx("MAC Address"), LmTools.fmt_str_upper(r.get("MACAddress")))
+                i = self.add_info_line(self._livebox_alist, i, lx("MAC Address"), LmUtils.fmt_str_upper(r.get("MACAddress")))
                 i = self.add_info_line(self._livebox_alist, i, lx("SSID"), r.get("SSID"))
-                i = self.add_info_line(self._livebox_alist, i, lx("SSID Advertisement"), LmTools.fmt_bool(r.get("SSIDAdvertisementEnabled")))
+                i = self.add_info_line(self._livebox_alist, i, lx("SSID Advertisement"), LmUtils.fmt_bool(r.get("SSIDAdvertisementEnabled")))
 
                 t = r.get("Security")
                 if t is not None:
@@ -872,10 +873,10 @@ class LmInfo:
 
                 t = r.get("WPS")
                 if t is not None:
-                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Enabled"), LmTools.fmt_bool(t.get("Enable")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Enabled"), LmUtils.fmt_bool(t.get("Enable")))
                     i = self.add_info_line(self._livebox_alist, i, lx("WPS Methods"), t.get("ConfigMethodsEnabled"))
                     i = self.add_info_line(self._livebox_alist, i, lx("WPS Self PIN"), t.get("SelfPIN"))
-                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Pairing In Progress"), LmTools.fmt_bool(t.get("PairingInProgress")))
+                    i = self.add_info_line(self._livebox_alist, i, lx("WPS Pairing In Progress"), LmUtils.fmt_bool(t.get("PairingInProgress")))
 
                 t = r.get("MACFiltering")
                 if t is not None:
@@ -891,25 +892,25 @@ class LmInfo:
         try:
             d = self._api._dhcp.get_info("default")
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             d = None
         else:
             d = d.get("default")
         if d is None:
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4"), "DHCPv4.Server:getDHCPServerPool query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Enabled"), LmTools.fmt_bool(d.get("Enable")))
+            i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Enabled"), LmUtils.fmt_bool(d.get("Enable")))
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Status"), d.get("Status"))
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Gateway"), d.get("Server"))
             i = self.add_info_line(self._livebox_alist, i, lx("Subnet Mask"), d.get("SubnetMask"))
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Start"), d.get("MinAddress"))
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 End"), d.get("MaxAddress"))
-            i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Lease Time"), LmTools.fmt_time(d.get("LeaseTime")))
+            i = self.add_info_line(self._livebox_alist, i, lx("DHCPv4 Lease Time"), LmUtils.fmt_time(d.get("LeaseTime")))
 
         try:
             d = self._api._dhcp.get_v6_server_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv6"), "DHCPv6.Server:getDHCPv6ServerStatus query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("DHCPv6 Status"), d)
@@ -917,7 +918,7 @@ class LmInfo:
         try:
             b, d = self._api._intf.get_eth_mibs()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("LAN"), "NeMo.Intf.lan:getMIBs query error", LmTools.ValQual.Error)
         else:
             for s in self._api._intf.get_list():
@@ -930,13 +931,13 @@ class LmInfo:
                 if (q is None) or (r is None):
                     continue
 
-                i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmTools.fmt_bool(q.get("Enable")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(q.get("Status")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Current Bit Rate"), LmTools.fmt_int(r.get("CurrentBitRate")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Bit Rate Supported"), LmTools.fmt_int(r.get("MaxBitRateSupported")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Enabled"), LmUtils.fmt_bool(q.get("Enable")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(q.get("Status")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Current Bit Rate"), LmUtils.fmt_int(r.get("CurrentBitRate")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Bit Rate Supported"), LmUtils.fmt_int(r.get("MaxBitRateSupported")))
                 i = self.add_info_line(self._livebox_alist, i, lx("Current Duplex Mode"), r.get("CurrentDuplexMode"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Power Saving Supported"), LmTools.fmt_bool(q.get("PowerSavingSupported")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Power Saving Enabled"), LmTools.fmt_bool(q.get("PowerSavingEnabled")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Power Saving Supported"), LmUtils.fmt_bool(q.get("PowerSavingSupported")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Power Saving Enabled"), LmUtils.fmt_bool(q.get("PowerSavingEnabled")))
 
         return i
 
@@ -950,14 +951,14 @@ class LmInfo:
             try:
                 d = self._api._intf.get_sfp_info()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(self._livebox_alist, i, lx("ONT"), "SFP:get query error", LmTools.ValQual.Error)
             else:
                 i = self.add_info_line(self._livebox_alist, i, lx("Status"), d.get("Status"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Connection Status"), LmTools.fmt_bool(d.get("ONTReady")))
-                i = self.add_info_line(self._livebox_alist, i, lx("SFP Status"), LmTools.fmt_int(d.get("DeviceState")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Operating State"), LmTools.fmt_int(d.get("OperatingState")))
-                i = self.add_info_line(self._livebox_alist, i, lx("Orange"), LmTools.fmt_bool(d.get("Orange")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Connection Status"), LmUtils.fmt_bool(d.get("ONTReady")))
+                i = self.add_info_line(self._livebox_alist, i, lx("SFP Status"), LmUtils.fmt_int(d.get("DeviceState")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Operating State"), LmUtils.fmt_int(d.get("OperatingState")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Orange"), LmUtils.fmt_bool(d.get("Orange")))
                 i = self.add_info_line(self._livebox_alist, i, lx("Serial Number"), d.get("SerialNumber"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Registration ID"), d.get("RegistrationID"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Local Registration ID"), d.get("LocalRegistrationID"))
@@ -969,25 +970,25 @@ class LmInfo:
                 if v is not None:
                     v /= 1000
                     i = self.add_info_line(self._livebox_alist, i, lx("Signal TxPower"), str(v) + " dBm")
-                i = self.add_info_line(self._livebox_alist, i, lx("Temperature"), LmTools.fmt_int(d.get("ChipsetTemperature")) + "°")
+                i = self.add_info_line(self._livebox_alist, i, lx("Temperature"), LmUtils.fmt_int(d.get("ChipsetTemperature")) + "°")
                 i = self.add_info_line(self._livebox_alist, i, lx("Model Name"), d.get("ModelName"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Manufacturer"), d.get("Manufacturer"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Hardware Version"), d.get("HardwareVersion"))
                 i = self.add_info_line(self._livebox_alist, i, lx("Firmware 1 Version"), d.get("Software1Version"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Firmware 1 State"), LmTools.fmt_int(d.get("Software1Status")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Firmware 1 State"), LmUtils.fmt_int(d.get("Software1Status")))
                 i = self.add_info_line(self._livebox_alist, i, lx("Firmware 2 Version"), d.get("Software2Version"))
-                i = self.add_info_line(self._livebox_alist, i, lx("Firmware 2 State"), LmTools.fmt_int(d.get("Software2Status")))
+                i = self.add_info_line(self._livebox_alist, i, lx("Firmware 2 State"), LmUtils.fmt_int(d.get("Software2Status")))
             return i
 
         # Get ONT info
         try:
             d = self._api._intf.get_ont_mibs()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("ONT"), "ONT MIBs query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("VEIP PPTP UNI"), LmTools.fmt_bool(d.get("VeipPptpUni")))
-            i = self.add_info_line(self._livebox_alist, i, lx("OMCI Is Tm Owner"), LmTools.fmt_bool(d.get("OmciIsTmOwner")))
+            i = self.add_info_line(self._livebox_alist, i, lx("VEIP PPTP UNI"), LmUtils.fmt_bool(d.get("VeipPptpUni")))
+            i = self.add_info_line(self._livebox_alist, i, lx("OMCI Is Tm Owner"), LmUtils.fmt_bool(d.get("OmciIsTmOwner")))
             v = d.get("MaxBitRateSupported")
             if v is not None:
                 i = self.add_info_line(self._livebox_alist, i, lx("Max Bit Rate Supported"), str(v / 1000) + " Gbps")
@@ -1067,29 +1068,29 @@ class LmInfo:
             i = self.add_info_line(self._livebox_alist, i, lx("Hardware Version"), d.get("HardwareVersion"))
             i = self.add_info_line(self._livebox_alist, i, lx("Equipment ID"), d.get("EquipmentId"))
             i = self.add_info_line(self._livebox_alist, i, lx("Vendor ID"), d.get("VendorId"))
-            i = self.add_info_line(self._livebox_alist, i, lx("Vendor Product Code"), LmTools.fmt_int(d.get("VendorProductCode")))
+            i = self.add_info_line(self._livebox_alist, i, lx("Vendor Product Code"), LmUtils.fmt_int(d.get("VendorProductCode")))
             i = self.add_info_line(self._livebox_alist, i, lx("Pon ID"), d.get("PonId"))
             i = self.add_info_line(self._livebox_alist, i, lx("Registration ID"), d.get("RegistrationID"))
             i = self.add_info_line(self._livebox_alist, i, lx("ONT Software Version 0"), d.get("ONTSoftwareVersion0"))
             i = self.add_info_line(self._livebox_alist, i, lx("ONT Software Version 1"), d.get("ONTSoftwareVersion1"))
-            i = self.add_info_line(self._livebox_alist, i, lx("ONT Software Version Active"), LmTools.fmt_int(d.get("ONTSoftwareVersionActive")))
+            i = self.add_info_line(self._livebox_alist, i, lx("ONT Software Version Active"), LmUtils.fmt_int(d.get("ONTSoftwareVersionActive")))
             i = self.add_info_line(self._livebox_alist, i, lx("ONU State"), d.get("ONUState"))
             rate = d.get("DownstreamMaxRate")
             if rate is not None:
                 rate *= 1024
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Down Bit Rate"), LmTools.fmt_bytes(rate))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Down Bit Rate"), LmUtils.fmt_bytes(rate))
             rate = d.get("UpstreamMaxRate")
             if rate is not None:
                 rate *= 1024
-                i = self.add_info_line(self._livebox_alist, i, lx("Max Up Bit Rate"), LmTools.fmt_bytes(rate))
+                i = self.add_info_line(self._livebox_alist, i, lx("Max Up Bit Rate"), LmUtils.fmt_bytes(rate))
             rate = d.get("DownstreamCurrRate")
             if rate is not None:
                 rate *= 1024
-                i = self.add_info_line(self._livebox_alist, i, lx("Current Down Bit Rate"), LmTools.fmt_bytes(rate))
+                i = self.add_info_line(self._livebox_alist, i, lx("Current Down Bit Rate"), LmUtils.fmt_bytes(rate))
             rate = d.get("UpstreamCurrRate")
             if rate is not None:
                 rate *= 1024
-                i = self.add_info_line(self._livebox_alist, i, lx("Current Up Bit Rate"), LmTools.fmt_bytes(rate))
+                i = self.add_info_line(self._livebox_alist, i, lx("Current Up Bit Rate"), LmUtils.fmt_bytes(rate))
 
         return i
 
@@ -1101,7 +1102,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("VoIP"), "VoiceService.VoiceApplication:listTrunks query error", LmTools.ValQual.Error)
         else:
             for q in d:
@@ -1125,7 +1126,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_name()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Name"), "DECT:getName query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Name"), d)
@@ -1133,7 +1134,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_pin()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("PIN"), "DECT:getPIN query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("PIN"), d)
@@ -1141,7 +1142,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_rfpi()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("RFPI"), "DECT:getRFPI query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("RFPI"), d)
@@ -1149,7 +1150,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_software_version()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Software Version"), "DECT:getVersion query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Software Version"), d)
@@ -1157,7 +1158,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_catiq_version()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("CAT-iq Version"), "DECT:getStandardVersion query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("CAT-iq Version"), d)
@@ -1165,7 +1166,7 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_pairing_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Pairing Status"), "DECT:getPairingStatus query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Pairing Status"), d)
@@ -1173,15 +1174,15 @@ class LmInfo:
         try:
             d = self._api._voip.get_dect_radio_state()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Radio State"), "DECT:getRadioState query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(self._livebox_alist, i, lx("Radio State"), LmTools.fmt_bool(d))
+            i = self.add_info_line(self._livebox_alist, i, lx("Radio State"), LmUtils.fmt_bool(d))
 
         try:
             d = self._api._voip.get_dect_repeater_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Repeater Status"), "DECT.Repeater:get query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Repeater Status"), d.get("Status"))
@@ -1196,7 +1197,7 @@ class LmInfo:
         try:
             d = self._api._iptv.get_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("IPTV Status"), "NMC.OrangeTV:getIPTVStatus query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("IPTV Status"), d)
@@ -1204,7 +1205,7 @@ class LmInfo:
         try:
             d = self._api._iptv.get_multi_screens_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("Multi Screens Status"), "NMC.OrangeTV:getIPTVMultiScreens query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(self._livebox_alist, i, lx("Multi Screens Status"), lx("Available") if d else lx("Disabled"))
@@ -1212,7 +1213,7 @@ class LmInfo:
         try:
             d = self._api._iptv.get_config()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("IPTV Config"), "NMC.OrangeTV:IPTVConfig query error", LmTools.ValQual.Error)
         else:
             for q in d:
@@ -1240,7 +1241,7 @@ class LmInfo:
         try:
             d = self._api._device.get_usb()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(self._livebox_alist, i, lx("USB"), "Devices:get query error", LmTools.ValQual.Error)
         else:
             for q in d:
@@ -1254,18 +1255,18 @@ class LmInfo:
                         i = self.add_title_line(self._livebox_alist, i, lx("USB Device Storage"))
                         i = self.add_info_line(self._livebox_alist, i, lx("Key"), q.get("Key"))
                         i = self.add_info_line(self._livebox_alist, i, lx("Device Type"), q.get("DeviceType"))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(q.get("Active")))
-                        i = self.add_info_line(self._livebox_alist, i, lx("First Seen"), LmTools.fmt_livebox_timestamp(q.get("FirstSeen")))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Last Connection"), LmTools.fmt_livebox_timestamp(q.get("LastConnection")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(q.get("Active")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("First Seen"), LmUtils.fmt_livebox_timestamp(q.get("FirstSeen")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Last Connection"), LmUtils.fmt_livebox_timestamp(q.get("LastConnection")))
                         i = self.add_info_line(self._livebox_alist, i, lx("File System"), q.get("FileSystem"))
                         n = q.get("Capacity")
                         if n is not None:
                             n *= 1024 * 1024
-                            i = self.add_info_line(self._livebox_alist, i, lx("Capacity"), LmTools.fmt_bytes(n))
+                            i = self.add_info_line(self._livebox_alist, i, lx("Capacity"), LmUtils.fmt_bytes(n))
                         n = q.get("UsedSpace")
                         if n is not None:
                             n *= 1024 * 1024
-                            i = self.add_info_line(self._livebox_alist, i, lx("Used Space"), LmTools.fmt_bytes(n))
+                            i = self.add_info_line(self._livebox_alist, i, lx("Used Space"), LmUtils.fmt_bytes(n))
 
                         names = q.get("Names")
                         if names:
@@ -1276,17 +1277,17 @@ class LmInfo:
                         i = self.add_title_line(self._livebox_alist, i, lx("USB Device"))
                         i = self.add_info_line(self._livebox_alist, i, lx("Name"), q.get("Name"))
                         i = self.add_info_line(self._livebox_alist, i, lx("Device Type"), q.get("DeviceType"))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmTools.fmt_bool(q.get("Active")))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Last Connection"), LmTools.fmt_livebox_timestamp(q.get("LastConnection")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Active"), LmUtils.fmt_bool(q.get("Active")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Last Connection"), LmUtils.fmt_livebox_timestamp(q.get("LastConnection")))
                         i = self.add_info_line(self._livebox_alist, i, lx("Location"), q.get("Location"))
                         i = self.add_info_line(self._livebox_alist, i, lx("Owner"), q.get("Owner"))
                         i = self.add_info_line(self._livebox_alist, i, lx("USB Version"), q.get("USBVersion"))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Device Version"), LmTools.fmt_int(q.get("DeviceVersion")))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Product ID"), LmTools.fmt_int(q.get("ProductID")))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Vendor ID"), LmTools.fmt_int(q.get("VendorID")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Device Version"), LmUtils.fmt_int(q.get("DeviceVersion")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Product ID"), LmUtils.fmt_int(q.get("ProductID")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Vendor ID"), LmUtils.fmt_int(q.get("VendorID")))
                         i = self.add_info_line(self._livebox_alist, i, lx("Manufacturer"), q.get("Manufacturer"))
                         i = self.add_info_line(self._livebox_alist, i, lx("Serial Number"), q.get("SerialNumber"))
-                        i = self.add_info_line(self._livebox_alist, i, lx("Port"), LmTools.fmt_int(q.get("Port")))
+                        i = self.add_info_line(self._livebox_alist, i, lx("Port"), LmUtils.fmt_int(q.get("Port")))
                         i = self.add_info_line(self._livebox_alist, i, lx("Rate"), q.get("Rate"))
 
         return i
@@ -1312,7 +1313,7 @@ class LiveboxStatsThread(LmThread):
             try:
                 d = self._api._stats.get_intf(s["Key"])
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
             else:
                 if isinstance(d, dict):
                     e = {"Key": s["Key"],

--- a/src/LiveboxMonitor/tabs/LmNatPatTab.py
+++ b/src/LiveboxMonitor/tabs/LmNatPatTab.py
@@ -6,7 +6,7 @@ from enum import IntEnum
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig, LmPatPtf
+from LiveboxMonitor.app import LmConfig, LmPatPtf
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget, NumericSortItem, CenteredIconsDelegate
@@ -14,6 +14,7 @@ from LiveboxMonitor.dlg.LmPatRule import PatRuleDialog
 from LiveboxMonitor.dlg.LmPtfRule import PtfRuleDialog
 from LiveboxMonitor.dlg.LmNatPatRuleType import NatPatRuleTypeDialog
 from LiveboxMonitor.lang.LmLanguages import get_nat_pat_label as lx, get_nat_pat_message as mx
+from LiveboxMonitor.util import LmUtils
 
 from LiveboxMonitor.__init__ import __build__
 
@@ -323,7 +324,7 @@ class LmNatPat:
             try:
                 export_file = open(file_name, "w")
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Cannot create the file.", "createFileErr"))
                 return
 
@@ -347,7 +348,7 @@ class LmNatPat:
             try:
                 export_file.close()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Cannot save the file.", "saveFileErr"))
 
             self.display_status(mx("{} rule(s) exported.", "ruleExport").format(c))
@@ -362,7 +363,7 @@ class LmNatPat:
         try:
             import_file = open(file_name, "r")
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot open the file.", "openFileErr"))
             return
 
@@ -370,7 +371,7 @@ class LmNatPat:
         try:
             file = json.load(import_file)
         except Exception as e:
-            LmTools.error(f"Error loading file: {e}")
+            LmUtils.error(f"Error loading file: {e}")
             self.display_error(mx("Wrong file format.", "fileFormatErr"))
             error = True
 
@@ -394,7 +395,7 @@ class LmNatPat:
         try:
             import_file.close()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot close the file.", "closeFileErr"))
 
         if not error:
@@ -523,7 +524,7 @@ class LmNatPat:
             try:
                 export_file = open(file_name, "w")
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Cannot create the file.", "createFileErr"))
                 return
 
@@ -547,7 +548,7 @@ class LmNatPat:
             try:
                 export_file.close()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self.display_error(mx("Cannot save the file.", "saveFileErr"))
 
             self.display_status(mx("{} rule(s) exported.", "ruleExport").format(c))
@@ -562,7 +563,7 @@ class LmNatPat:
         try:
             import_file = open(file_name, "r")
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot open the file.", "openFileErr"))
             return
 
@@ -570,7 +571,7 @@ class LmNatPat:
         try:
             file = json.load(import_file)
         except Exception as e:
-            LmTools.error(f"Error loading file: {e}")
+            LmUtils.error(f"Error loading file: {e}")
             self.display_error(mx("Wrong file format.", "fileFormatErr"))
             error = True
 
@@ -594,7 +595,7 @@ class LmNatPat:
         try:
             import_file.close()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot close the file.", "closeFileErr"))
 
         if not error:
@@ -644,7 +645,7 @@ class LmNatPat:
         try:
             d = self._api._firewall.get_ipv4_port_forwarding()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot load IPv4 port forwarding rules.", "patLoadErr"))
             return
 
@@ -691,8 +692,8 @@ class LmNatPat:
         try:
             d = self._api._firewall.get_ipv6_pinhole()
         except Exception as e:
-            LmTools.error(str(e))
-            LmTools.error("Cannot load IPv6 port forwarding rules.")    # Do not display a dialog as not all LB models have this API
+            LmUtils.error(str(e))
+            LmUtils.error("Cannot load IPv6 port forwarding rules.")    # Do not display a dialog as not all LB models have this API
             return
 
         i = self._pat_list.rowCount()
@@ -769,55 +770,55 @@ class LmNatPat:
     ### Check a PAT rule object consistency
     def check_pat_rule(self, rule):
         if rule.get("Enable") is None:
-            LmTools.error("Rule as no Enable tag.")
+            LmUtils.error("Rule as no Enable tag.")
             return False
 
         t = rule.get("Type", "UNK")
         if t not in LmPatPtf.RULE_PAT_TYPES:
-            LmTools.error(f"Rule has unknown {t} type.")
+            LmUtils.error(f"Rule has unknown {t} type.")
             return False
 
         if len(rule.get("Name", "")) == 0:
-            LmTools.error("Rule has no Name.")
+            LmUtils.error("Rule has no Name.")
             return False
 
         protocols = rule.get("ProtoNumbers", "")
         if len(protocols) == 0:
-            LmTools.error("Rule has no protocol.")
+            LmUtils.error("Rule has no protocol.")
             return False
 
         for p in protocols.split(","):
             n = LmPatPtf.PROTOCOL_NAMES.get(p)
             if n is None:
-                LmTools.error(f"Rule has wrong protocol {p} set.")
+                LmUtils.error(f"Rule has wrong protocol {p} set.")
                 return False
             n = int(p)
             if (n != LmPatPtf.Protocols.TCP) and (n != LmPatPtf.Protocols.UDP):
-                LmTools.error(f"Rule has wrong protocol {p} set.")
+                LmUtils.error(f"Rule has wrong protocol {p} set.")
                 return False
 
         n = rule.get("IntPort", "")
         if n:
-            if not LmTools.is_tcp_udp_port(n):
-                LmTools.error(f"Rule has wrong internal port {n} set.")
+            if not LmUtils.is_tcp_udp_port(n):
+                LmUtils.error(f"Rule has wrong internal port {n} set.")
                 return False
 
         n = rule.get("ExtPort", "")
         if n:
-            if not LmTools.is_tcp_udp_port(n):
-                LmTools.error(f"Rule has wrong external port {n} set.")
+            if not LmUtils.is_tcp_udp_port(n):
+                LmUtils.error(f"Rule has wrong external port {n} set.")
                 return False
 
         ip = rule.get("IP", "")
         if len(ip) == 0:
             return False
         if t == LmPatPtf.RULE_TYPE_IPv6:
-            if not LmTools.is_ipv6(ip):
-                LmTools.error(f"Rule has wrong IPv6 {ip} set.")
+            if not LmUtils.is_ipv6(ip):
+                LmUtils.error(f"Rule has wrong IPv6 {ip} set.")
                 return False
         else:
-            if not LmTools.is_ipv4(ip):
-                LmTools.error(f"Rule has wrong IPv4 {ip} set.")
+            if not LmUtils.is_ipv4(ip):
+                LmUtils.error(f"Rule has wrong IPv4 {ip} set.")
                 return False
 
         e = rule.get("ExtIPs", "")
@@ -825,16 +826,16 @@ class LmNatPat:
             ext_ips = e.split(",")
             for ip in ext_ips:
                 if len(ip) == 0:
-                    LmTools.error("Rule external IPs has an empty IP address.")
+                    LmUtils.error("Rule external IPs has an empty IP address.")
                     return False
 
                 if t == LmPatPtf.RULE_TYPE_IPv6:
-                    if not LmTools.is_ipv6(ip):
-                        LmTools.error(f"Rule external IPs has a wrong IPv6 {ip} set.")
+                    if not LmUtils.is_ipv6(ip):
+                        LmUtils.error(f"Rule external IPs has a wrong IPv6 {ip} set.")
                         return False
                 else:
-                    if not LmTools.is_ipv4(ip):
-                        LmTools.error(f"Rule external IPs has a wrong IPv4 {ip} set.")
+                    if not LmUtils.is_ipv4(ip):
+                        LmUtils.error(f"Rule external IPs has a wrong IPv4 {ip} set.")
                         return False
 
         return True
@@ -980,7 +981,7 @@ class LmNatPat:
         try:
             d = self._api._firewall.get_ipv4_protocol_forwarding()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot load IPv4 protocol forwarding rules.", "ptfLoadErr"))
             return
 
@@ -1022,8 +1023,8 @@ class LmNatPat:
         try:
             d = self._api._firewall.get_ipv6_pinhole()
         except Exception as e:
-            LmTools.error(str(e))
-            LmTools.error("Cannot load IPv6 protocol forwarding rules.")    # Do not display a dialog as not all LB models have this API
+            LmUtils.error(str(e))
+            LmUtils.error("Cannot load IPv6 protocol forwarding rules.")    # Do not display a dialog as not all LB models have this API
             return
 
         i = self._ptf_list.rowCount()
@@ -1093,38 +1094,38 @@ class LmNatPat:
     ### Check a PTF rule object consistency
     def check_ptf_rule(self, rule):
         if rule.get("Enable") is None:
-            LmTools.error("Rule as no Enable tag.")
+            LmUtils.error("Rule as no Enable tag.")
             return False
 
         t = rule.get("Type", "UNK")
         if t not in LmPatPtf.RULE_PTF_TYPES:
-            LmTools.error(f"Rule has unknown {t} type.")
+            LmUtils.error(f"Rule has unknown {t} type.")
             return False
 
         if len(rule.get("Name", "")) == 0:
-            LmTools.error("Rule has no Name.")
+            LmUtils.error("Rule has no Name.")
             return False
 
         protocols = rule.get("ProtoNumbers", "")
         if len(protocols) == 0:
-            LmTools.error("Rule has no protocol.")
+            LmUtils.error("Rule has no protocol.")
             return False
 
         for p in protocols.split(","):
             if LmPatPtf.PROTOCOL_NAMES.get(p) is None:
-                LmTools.error(f"Rule has wrong protocol {p} set.")
+                LmUtils.error(f"Rule has wrong protocol {p} set.")
                 return False
 
         ip = rule.get("IP", "")
         if len(ip) == 0:
             return False
         if t == LmPatPtf.RULE_TYPE_IPv6:
-            if not LmTools.is_ipv6_pfix(ip):
-                LmTools.error(f"Rule has wrong IPv6 {ip} set.")
+            if not LmUtils.is_ipv6_pfix(ip):
+                LmUtils.error(f"Rule has wrong IPv6 {ip} set.")
                 return False
         else:
-            if not LmTools.is_ipv4(ip):
-                LmTools.error(f"Rule has wrong IPv4 {ip} set.")
+            if not LmUtils.is_ipv4(ip):
+                LmUtils.error(f"Rule has wrong IPv4 {ip} set.")
                 return False
 
         e = rule.get("ExtIPs", "")
@@ -1132,16 +1133,16 @@ class LmNatPat:
             ext_ips = e.split(",")
             for ip in ext_ips:
                 if len(ip) == 0:
-                    LmTools.error("Rule external IPs has an empty IP address.")
+                    LmUtils.error("Rule external IPs has an empty IP address.")
                     return False
 
                 if t == LmPatPtf.RULE_TYPE_IPv6:
-                    if not LmTools.is_ipv6(ip):
-                        LmTools.error(f"Rule external IPs has a wrong IPv6 {ip} set.")
+                    if not LmUtils.is_ipv6(ip):
+                        LmUtils.error(f"Rule external IPs has a wrong IPv6 {ip} set.")
                         return False
                 else:
-                    if not LmTools.is_ipv4(ip):
-                        LmTools.error(f"Rule external IPs has a wrong IPv4 {ip} set.")
+                    if not LmUtils.is_ipv4(ip):
+                        LmUtils.error(f"Rule external IPs has a wrong IPv4 {ip} set.")
                         return False
 
         return True
@@ -1239,7 +1240,7 @@ class LmNatPat:
         try:
             self._api._firewall.commit()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             return False
         return True
 

--- a/src/LiveboxMonitor/tabs/LmPhoneTab.py
+++ b/src/LiveboxMonitor/tabs/LmPhoneTab.py
@@ -8,12 +8,13 @@ from enum import IntEnum
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from LiveboxMonitor.app import LmTools, LmConfig
+from LiveboxMonitor.app import LmConfig
 from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.app.LmTableWidget import LmTableWidget, NumericSortItem, CenteredIconsDelegate
 from LiveboxMonitor.dlg.LmEditContact import EditContactDialog
 from LiveboxMonitor.lang.LmLanguages import get_phone_label as lx, get_phone_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -417,7 +418,7 @@ class LmPhone:
         try:
             call_list = self._api._voip.get_call_list()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Error getting phone call list.", "callLoad"))
         else:
             for i, c in enumerate(call_list):
@@ -447,7 +448,7 @@ class LmPhone:
                         call_type_icon.setData(QtCore.Qt.ItemDataRole.UserRole, CallType.Missed)
                         missed_call = True
 
-                time = QtWidgets.QTableWidgetItem(LmTools.fmt_livebox_timestamp(c.get("startTime")))
+                time = QtWidgets.QTableWidgetItem(LmUtils.fmt_livebox_timestamp(c.get("startTime")))
                 time.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
                 number = QtWidgets.QTableWidgetItem(c.get("remoteNumber"))
                 number.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -456,7 +457,7 @@ class LmPhone:
                 contact = QtWidgets.QTableWidgetItem(contact_str)
 
                 seconds = c.get("duration")
-                duration = NumericSortItem(LmTools.fmt_time(seconds, True))
+                duration = NumericSortItem(LmUtils.fmt_time(seconds, True))
                 duration.setData(QtCore.Qt.ItemDataRole.UserRole, seconds)
                 duration.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
 
@@ -575,9 +576,9 @@ class LmPhone:
                 spam = data.get("blocked")
                 if spam is not None:
                     return spam != 0
-                LmTools.error("CallFilter response error: no blocked field")
+                LmUtils.error("CallFilter response error: no blocked field")
             except Exception as e:
-                LmTools.error(f"CallFilter error: {e}")
+                LmUtils.error(f"CallFilter error: {e}")
         return False
 
 
@@ -661,7 +662,7 @@ class LmPhone:
         try:
             export_file = open(file_name, "w", encoding="utf-8")  # VCF standard charset is UTF-8
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot create the file.", "createFileErr"))
             return
 
@@ -669,7 +670,7 @@ class LmPhone:
         try:
             contact_list = self._api._voip.get_contact_list()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Error getting contact list.", "contactLoad"))
         else:
             for c in contact_list:
@@ -690,7 +691,7 @@ class LmPhone:
         try:
             export_file.close()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Cannot save the file.", "saveFileErr"))
 
 
@@ -781,7 +782,7 @@ class LmPhone:
                     case _:
                         LmPhone.import_vcf_tag(c, tag, tag_params, l)
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             f.close()
             return 0
 
@@ -868,7 +869,7 @@ class LmPhone:
         try:
             contact_list = self._api._voip.get_contact_list()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             self.display_error(mx("Error getting contact list.", "contactLoad"))
         else:
             for i, c in enumerate(contact_list):

--- a/src/LiveboxMonitor/tabs/LmRepeaterTab.py
+++ b/src/LiveboxMonitor/tabs/LmRepeaterTab.py
@@ -17,6 +17,7 @@ from LiveboxMonitor.dlg.LmRebootHistory import RebootHistoryDialog
 from LiveboxMonitor.dlg.LmCallApi import CallApiDialog
 from LiveboxMonitor.tabs.LmInfoTab import InfoCol, StatsCol
 from LiveboxMonitor.lang.LmLanguages import get_repeater_label as lx, get_repeater_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -252,7 +253,7 @@ class LmRepeater:
             except KeyError:
                 model = WIFI_REPEATER_DEFAULT_MODEL
 
-            ip_struct = LmTools.determine_ip(device)
+            ip_struct = LmUtils.determine_ip(device)
             ip_address = ip_struct.get("Address") if ip_struct else None
 
             active = device.get("Active", False)
@@ -409,20 +410,20 @@ class LmRepeater:
         # Update UI
         list_line = r.find_stats_line(key)
         if list_line >= 0:
-            down = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(down_bytes))
+            down = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(down_bytes))
             down.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
             if down_errors:
                 down.setForeground(QtCore.Qt.GlobalColor.red)
             r._stats_list.setItem(list_line, StatsCol.Down, down)
 
-            up = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(up_bytes))
+            up = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(up_bytes))
             up.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
             if up_errors:
                 up.setForeground(QtCore.Qt.GlobalColor.red)
             r._stats_list.setItem(list_line, StatsCol.Up, up)
 
             if down_rate_bytes:
-                down_rate = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(down_rate_bytes) + "/s")
+                down_rate = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(down_rate_bytes) + "/s")
                 if down_delta_errors:
                     down_rate.setForeground(QtCore.Qt.GlobalColor.red)
                 down_rate.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
@@ -431,7 +432,7 @@ class LmRepeater:
             r._stats_list.setItem(list_line, StatsCol.DownRate, down_rate)
 
             if up_rate_bytes:
-                up_rate = QtWidgets.QTableWidgetItem(LmTools.fmt_bytes(up_rate_bytes) + "/s")
+                up_rate = QtWidgets.QTableWidgetItem(LmUtils.fmt_bytes(up_rate_bytes) + "/s")
                 if up_delta_errors:
                     up_rate.setForeground(QtCore.Qt.GlobalColor.red)
                 up_rate.setTextAlignment(QtCore.Qt.AlignmentFlag.AlignRight | QtCore.Qt.AlignmentFlag.AlignVCenter)
@@ -489,7 +490,7 @@ class LmRepHandler:
                 # Need to ignore cookie as sessions opened with >1h cookie generate errors
                 r = session.signin(user, password, True)
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 r = -1
             if r > 0:
                 self._signed = True
@@ -618,7 +619,7 @@ class LmRepHandler:
 
     ### Process a device updated event
     def process_device_updated_event(self, event):
-        ipv4_struct = LmTools.determine_ip(event)
+        ipv4_struct = LmUtils.determine_ip(event)
         ipv4 = ipv4_struct.get("Address") if ipv4_struct else None
         if self._ip_addr != ipv4:
             self.process_ip_address_event(ipv4)
@@ -700,7 +701,7 @@ class LmRepHandler:
             try:
                 self._app._export_file = open(file_name, "w")
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 self._app.display_error(mx("Cannot create the file.", "createFileErr"))
                 return
 
@@ -716,7 +717,7 @@ class LmRepHandler:
                 try:
                     self._app._export_file.close()
                 except Exception as e:
-                    LmTools.error(str(e))
+                    LmUtils.error(str(e))
                     self._app.display_error(mx("Cannot save the file.", "saveFileErr"))
 
                 self._app._export_file = None
@@ -888,24 +889,24 @@ class LmRepHandler:
         try:
             d = self._api._info.get_device_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("Repeater Infos"), "DeviceInfo:get query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(i, lx("Model Name"), d.get("ModelName"))
-            i = self.add_info_line(i, lx("Repeater Up Time"), LmTools.fmt_time(d.get("UpTime")))
+            i = self.add_info_line(i, lx("Repeater Up Time"), LmUtils.fmt_time(d.get("UpTime")))
             i = self.add_info_line(i, lx("Serial Number"), d.get("SerialNumber"))
             i = self.add_info_line(i, lx("Hardware Version"), d.get("HardwareVersion"))
             i = self.add_info_line(i, lx("Software Version"), d.get("SoftwareVersion"))
             i = self.add_info_line(i, lx("Orange Firmware Version"), d.get("AdditionalSoftwareVersion"))
-            i = self.add_info_line(i, lx("Country"), LmTools.fmt_str_upper(d.get("Country")))
+            i = self.add_info_line(i, lx("Country"), LmUtils.fmt_str_upper(d.get("Country")))
 
         try:
             d = self._api._reboot.get_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("Repeater Infos"), "NMC.Reboot:get query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(i, lx("Total Number Of Reboots"), LmTools.fmt_int(d.get("BootCounter")))
+            i = self.add_info_line(i, lx("Total Number Of Reboots"), LmUtils.fmt_int(d.get("BootCounter")))
 
         try:
             d = self._api._info.get_time()
@@ -926,15 +927,15 @@ class LmRepHandler:
         try:
             d = self._api._wifi.get_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("Wifi"), "NMC.Wifi:get query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(i, lx("Enabled"), LmTools.fmt_bool(d.get("Enable")))
-            i = self.add_info_line(i, lx("Active"), LmTools.fmt_bool(d.get("Status")))
+            i = self.add_info_line(i, lx("Enabled"), LmUtils.fmt_bool(d.get("Enable")))
+            i = self.add_info_line(i, lx("Active"), LmUtils.fmt_bool(d.get("Status")))
             i = self.add_info_line(i, lx("Mode"), d.get("EnableTarget"))
             i = self.add_info_line(i, lx("WPS Mode"), d.get("WPSMode"))
             i = self.add_info_line(i, lx("Link Type"), d.get("CurrentBackhaul"))
-            i = self.add_info_line(i, lx("Read Only"), LmTools.fmt_bool(d.get("ReadOnlyStatus")))
+            i = self.add_info_line(i, lx("Read Only"), LmUtils.fmt_bool(d.get("ReadOnlyStatus")))
             i = self.add_info_line(i, lx("Pairing Status"), d.get("PairingStatus"))
             i = self.add_info_line(i, lx("PIN Code"), d.get("PINCode"))
 
@@ -942,16 +943,16 @@ class LmRepHandler:
             try:
                 d = self._api._wifi.get_scheduler_enable()
             except Exception as e:
-                LmTools.error(str(e))
+                LmUtils.error(str(e))
                 i = self.add_info_line(i, lx("Scheduler Enabled"), "Scheduler:getCompleteSchedules query error", LmTools.ValQual.Error)
             else:
-                 i = self.add_info_line(i, lx("Scheduler Enabled"), LmTools.fmt_bool(d))
+                 i = self.add_info_line(i, lx("Scheduler Enabled"), LmUtils.fmt_bool(d))
 
 
         try:
             b, w, d = self._api._intf.get_wifi_mibs()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("Wifi"), "NeMo.Intf.lan:getMIBs query error", LmTools.ValQual.Error)
         else:
             for s in self._netIntf:
@@ -963,8 +964,8 @@ class LmRepHandler:
                 intf_key = None
                 base = b.get(s["Key"])
                 if base is not None:
-                    i = self.add_info_line(i, lx("Enabled"), LmTools.fmt_bool(base.get("Enable")))
-                    i = self.add_info_line(i, lx("Active"), LmTools.fmt_bool(base.get("Status")))
+                    i = self.add_info_line(i, lx("Enabled"), LmUtils.fmt_bool(base.get("Enable")))
+                    i = self.add_info_line(i, lx("Active"), LmUtils.fmt_bool(base.get("Status")))
                     low_level_intf = base.get("LLIntf")
                     if low_level_intf is not None:
                         intf_key = next(iter(low_level_intf))
@@ -976,10 +977,10 @@ class LmRepHandler:
 
                 i = self.add_info_line(i, lx("Radio Status"), q.get("RadioStatus"))
                 i = self.add_info_line(i, lx("VAP Status"), r.get("VAPStatus"))
-                i = self.add_info_line(i, lx("Vendor Name"), LmTools.fmt_str_upper(q.get("VendorName")))
-                i = self.add_info_line(i, lx("MAC Address"), LmTools.fmt_str_upper(r.get("MACAddress")))
+                i = self.add_info_line(i, lx("Vendor Name"), LmUtils.fmt_str_upper(q.get("VendorName")))
+                i = self.add_info_line(i, lx("MAC Address"), LmUtils.fmt_str_upper(r.get("MACAddress")))
                 i = self.add_info_line(i, lx("SSID"), r.get("SSID"))
-                i = self.add_info_line(i, lx("SSID Advertisement"), LmTools.fmt_bool(r.get("SSIDAdvertisementEnabled")))
+                i = self.add_info_line(i, lx("SSID Advertisement"), LmUtils.fmt_bool(r.get("SSIDAdvertisementEnabled")))
 
                 t = r.get("Security")
                 if t is not None:
@@ -990,31 +991,31 @@ class LmRepHandler:
 
                 t = r.get("WPS")
                 if t is not None:
-                    i = self.add_info_line(i, lx("WPS Enabled"), LmTools.fmt_bool(t.get("Enable")))
+                    i = self.add_info_line(i, lx("WPS Enabled"), LmUtils.fmt_bool(t.get("Enable")))
                     i = self.add_info_line(i, lx("WPS Methods"), t.get("ConfigMethodsEnabled"))
                     i = self.add_info_line(i, lx("WPS Self PIN"), t.get("SelfPIN"))
-                    i = self.add_info_line(i, lx("WPS Pairing In Progress"), LmTools.fmt_bool(t.get("PairingInProgress")))
+                    i = self.add_info_line(i, lx("WPS Pairing In Progress"), LmUtils.fmt_bool(t.get("PairingInProgress")))
 
                 t = r.get("MACFiltering")
                 if t is not None:
                     i = self.add_info_line(i, lx("MAC Filtering"), t.get("Mode"))
 
-                i = self.add_info_line(i, lx("Max Bitrate"), LmTools.fmt_int(q.get("MaxBitRate")))
-                i = self.add_info_line(i, lx("AP Mode"), LmTools.fmt_bool(q.get("AP_Mode")))
-                i = self.add_info_line(i, lx("STA Mode"), LmTools.fmt_bool(q.get("STA_Mode")))
-                i = self.add_info_line(i, lx("WDS Mode"), LmTools.fmt_bool(q.get("WDS_Mode")))
-                i = self.add_info_line(i, lx("WET Mode"), LmTools.fmt_bool(q.get("WET_Mode")))
+                i = self.add_info_line(i, lx("Max Bitrate"), LmUtils.fmt_int(q.get("MaxBitRate")))
+                i = self.add_info_line(i, lx("AP Mode"), LmUtils.fmt_bool(q.get("AP_Mode")))
+                i = self.add_info_line(i, lx("STA Mode"), LmUtils.fmt_bool(q.get("STA_Mode")))
+                i = self.add_info_line(i, lx("WDS Mode"), LmUtils.fmt_bool(q.get("WDS_Mode")))
+                i = self.add_info_line(i, lx("WET Mode"), LmUtils.fmt_bool(q.get("WET_Mode")))
                 i = self.add_info_line(i, lx("Frequency Band"), q.get("OperatingFrequencyBand"))
                 i = self.add_info_line(i, lx("Channel Bandwidth"), q.get("CurrentOperatingChannelBandwidth"))
                 i = self.add_info_line(i, lx("Standard"), q.get("OperatingStandards"))
-                i = self.add_info_line(i, lx("Channel"), LmTools.fmt_int(q.get("Channel")))
-                i = self.add_info_line(i, lx("Auto Channel Supported"), LmTools.fmt_bool(q.get("AutoChannelSupported")))
-                i = self.add_info_line(i, lx("Auto Channel Enabled"), LmTools.fmt_bool(q.get("AutoChannelEnable")))
+                i = self.add_info_line(i, lx("Channel"), LmUtils.fmt_int(q.get("Channel")))
+                i = self.add_info_line(i, lx("Auto Channel Supported"), LmUtils.fmt_bool(q.get("AutoChannelSupported")))
+                i = self.add_info_line(i, lx("Auto Channel Enabled"), LmUtils.fmt_bool(q.get("AutoChannelEnable")))
                 i = self.add_info_line(i, lx("Channel Change Reason"), q.get("ChannelChangeReason"))
-                i = self.add_info_line(i, lx("Max Associated Devices"), LmTools.fmt_int(q.get("MaxAssociatedDevices")))
-                i = self.add_info_line(i, lx("Active Associated Devices"), LmTools.fmt_int(q.get("ActiveAssociatedDevices")))
-                i = self.add_info_line(i, lx("Noise"), LmTools.fmt_int(q.get("Noise")))
-                i = self.add_info_line(i, lx("Antenna Defect"), LmTools.fmt_bool(q.get("AntennaDefect")))
+                i = self.add_info_line(i, lx("Max Associated Devices"), LmUtils.fmt_int(q.get("MaxAssociatedDevices")))
+                i = self.add_info_line(i, lx("Active Associated Devices"), LmUtils.fmt_int(q.get("ActiveAssociatedDevices")))
+                i = self.add_info_line(i, lx("Noise"), LmUtils.fmt_int(q.get("Noise")))
+                i = self.add_info_line(i, lx("Antenna Defect"), LmUtils.fmt_bool(q.get("AntennaDefect")))
 
         return i
 
@@ -1026,13 +1027,13 @@ class LmRepHandler:
         try:
             d = self._api._info.get_wan_status()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("LAN Infos"), "NMC:getWANStatus query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(i, lx("MAC Address"), LmTools.fmt_str_upper(d.get("MACAddress")))
-            i = self.add_info_line(i, lx("Link Status"), LmTools.fmt_str_capitalize(d.get("LinkState")))
-            i = self.add_info_line(i, lx("Link Type"), LmTools.fmt_str_upper(d.get("LinkType")))
-            i = self.add_info_line(i, lx("Protocol"), LmTools.fmt_str_upper(d.get("Protocol")))
+            i = self.add_info_line(i, lx("MAC Address"), LmUtils.fmt_str_upper(d.get("MACAddress")))
+            i = self.add_info_line(i, lx("Link Status"), LmUtils.fmt_str_capitalize(d.get("LinkState")))
+            i = self.add_info_line(i, lx("Link Type"), LmUtils.fmt_str_upper(d.get("LinkType")))
+            i = self.add_info_line(i, lx("Protocol"), LmUtils.fmt_str_upper(d.get("Protocol")))
             i = self.add_info_line(i, lx("Connection Status"), d.get("ConnectionState"))
             i = self.add_info_line(i, lx("Last Connection Error"), d.get("LastConnectionError"))
             i = self.add_info_line(i, lx("IP Address"), d.get("IPAddress"))
@@ -1043,27 +1044,27 @@ class LmRepHandler:
         try:
             d = self._api._info.get_mtu()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("MTU"), "NeMo.Intf.data:getFirstParameter query error", LmTools.ValQual.Error)
         else:
-            i = self.add_info_line(i, lx("MTU"), LmTools.fmt_int(d))
+            i = self.add_info_line(i, lx("MTU"), LmUtils.fmt_int(d))
 
         i = self.add_title_line(i, lx("Link to the Livebox"))
 
         try:
             d = self._api._info.get_uplink_info()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("Livebox link Infos"), "UplinkMonitor.DefaultGateway:get query error", LmTools.ValQual.Error)
         else:
             i = self.add_info_line(i, lx("IP Address"), d.get("IPv4Address"))
-            i = self.add_info_line(i, lx("MAC Address"), LmTools.fmt_str_upper(d.get("MACAddress")))
-            i = self.add_info_line(i, lx("Interface"), LmTools.fmt_str_capitalize(d.get("NeMoIntfName")))
+            i = self.add_info_line(i, lx("MAC Address"), LmUtils.fmt_str_upper(d.get("MACAddress")))
+            i = self.add_info_line(i, lx("Interface"), LmUtils.fmt_str_capitalize(d.get("NeMoIntfName")))
 
         try:
             b, d = self._api._intf.get_eth_mibs()
         except Exception as e:
-            LmTools.error(str(e))
+            LmUtils.error(str(e))
             i = self.add_info_line(i, lx("LAN"), "NeMo.Intf.lan:getMIBs query error", LmTools.ValQual.Error)
         else:
             for s in self._netIntf:
@@ -1076,13 +1077,13 @@ class LmRepHandler:
                 if (q is None) or (r is None):
                     continue
 
-                i = self.add_info_line(i, lx("Enabled"), LmTools.fmt_bool(q.get("Enable")))
-                i = self.add_info_line(i, lx("Active"), LmTools.fmt_bool(q.get("Status")))
-                i = self.add_info_line(i, lx("Current Bit Rate"), LmTools.fmt_int(r.get("CurrentBitRate")))
-                i = self.add_info_line(i, lx("Max Bit Rate Supported"), LmTools.fmt_int(r.get("MaxBitRateSupported")))
+                i = self.add_info_line(i, lx("Enabled"), LmUtils.fmt_bool(q.get("Enable")))
+                i = self.add_info_line(i, lx("Active"), LmUtils.fmt_bool(q.get("Status")))
+                i = self.add_info_line(i, lx("Current Bit Rate"), LmUtils.fmt_int(r.get("CurrentBitRate")))
+                i = self.add_info_line(i, lx("Max Bit Rate Supported"), LmUtils.fmt_int(r.get("MaxBitRateSupported")))
                 i = self.add_info_line(i, lx("Current Duplex Mode"), r.get("CurrentDuplexMode"))
-                i = self.add_info_line(i, lx("Power Saving Supported"), LmTools.fmt_bool(q.get("PowerSavingSupported")))
-                i = self.add_info_line(i, lx("Power Saving Enabled"), LmTools.fmt_bool(q.get("PowerSavingEnabled")))
+                i = self.add_info_line(i, lx("Power Saving Supported"), LmUtils.fmt_bool(q.get("PowerSavingSupported")))
+                i = self.add_info_line(i, lx("Power Saving Enabled"), LmUtils.fmt_bool(q.get("PowerSavingEnabled")))
 
         return i
 
@@ -1115,7 +1116,7 @@ class RepeaterStatsThread(LmThread):
                         try:
                             d = r._api._stats.get_intf(s["Key"])
                         except Exception as e:
-                            LmTools.error(str(e))
+                            LmUtils.error(str(e))
                             # If session has timed out on Repeater side, resign
                             r.signin(silent=True)
                         else:

--- a/src/LiveboxMonitor/tabs/LmTvDecoderTab.py
+++ b/src/LiveboxMonitor/tabs/LmTvDecoderTab.py
@@ -7,6 +7,7 @@ from LiveboxMonitor.app.LmConfig import LmConf
 from LiveboxMonitor.app.LmThread import LmThread
 from LiveboxMonitor.app.LmIcons import LmIcon
 from LiveboxMonitor.lang.LmLanguages import get_tvdecoder_label as lx, get_tvdecoder_message as mx
+from LiveboxMonitor.util import LmUtils
 
 
 # ################################ VARS & DEFS ################################
@@ -244,7 +245,7 @@ class LmTvHandler:
 
     ### Process a device updated event
     def process_device_updated_event(self, event):
-        ipv4_struct = LmTools.determine_ip(event)
+        ipv4_struct = LmUtils.determine_ip(event)
         ipv4 = ipv4_struct.get("Address") if ipv4_struct else None
         if self._ip_addr != ipv4:
             self.process_ip_address_event(ipv4)

--- a/src/LiveboxMonitor/util/LmUtils.py
+++ b/src/LiveboxMonitor/util/LmUtils.py
@@ -1,0 +1,317 @@
+### Livebox Monitor utils module ###
+
+import datetime
+from email.message import EmailMessage
+from email.utils import formatdate
+import re
+import smtplib
+import ssl
+import sys
+
+from dateutil import tz
+
+from LiveboxMonitor.lang.LmLanguages import get_tools_label as lx
+
+
+# ################################ VARS & DEFS ################################
+
+# Debug verbosity
+verbosity = 1
+
+# Regular expressions - https://ihateregex.io/
+MAC_RS = r"(?:[0-9A-Fa-f]{2}[:-]){5}(?:[0-9A-Fa-f]{2})"
+IPv4_RS = r"(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}"
+IPv4Pfix_RS = r"((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\/(3[0-2]|[12]?[0-9]))?"
+IPv6_RS = (r"(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|"
+           r"([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|"
+           r"([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|"
+           r"([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|"
+           r":((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|"
+           r"::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|"
+           r"1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.)"
+           r"{3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))")
+IPv6Pfix_RS = (r"(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|(?:[0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}|"
+               r"(?:[0-9A-Fa-f]{1,4}:){1,5}(:[0-9A-Fa-f]{1,4}){1,2}|(?:[0-9A-Fa-f]{1,4}:){1,4}(:[0-9A-Fa-f]{1,4}){1,3}|"
+               r"(?:[0-9A-Fa-f]{1,4}:){1,3}(:[0-9A-Fa-f]{1,4}){1,4}|(?:[0-9A-Fa-f]{1,4}:){1,2}(:[0-9A-Fa-f]{1,4}){1,5}|"
+               r"[0-9A-Fa-f]{1,4}:((:[0-9A-Fa-f]{1,4}){1,6})|:(?:(:[0-9A-Fa-f]{1,4}){1,7}|:)|fe80:(:[0-9A-Fa-f]{0,4}){0,4}%[0-9a-zA-Z]{1,}|"
+               r"::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|"
+               r"([0-9A-Fa-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))"
+               r"(?:\/(?:12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))?")
+PORTS_RS = (r"^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$|"
+            r"^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})-(6553[0-5]|"
+            r"655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})$")
+EMAIL_RS = r"[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+"
+
+# Useful objects
+MAC_RE = re.compile(MAC_RS)
+IPv4_RE = re.compile(f"^{IPv4_RS}$")
+IPv4Pfix_RE = re.compile(f"^{IPv4Pfix_RS}$")
+IPv6_RE = re.compile(f"^{IPv6_RS}$")
+IPv6Pfix_RE = re.compile(f"^{IPv6Pfix_RS}$")
+PORTS_RE = re.compile(PORTS_RS)
+EMAIL_RE = re.compile(EMAIL_RS)
+
+
+
+# ################################ Tools ################################
+
+### Set verbosity
+def set_verbosity(level):
+    global verbosity
+    verbosity = level
+
+
+### Get verbosity
+def get_verbosity():
+    return verbosity
+
+
+### Debug logging according to level
+def log_debug(level, *args):
+    if verbosity >= level:
+        sys.stderr.write(f"###DEBUG-L{level}: {' '.join(args)}\n")
+
+
+### Output error on stderr
+def error(*args, **kwargs):
+    print("###ERROR:", *args, file=sys.stderr, **kwargs)
+
+
+### Extract a valid MAC Addr from any string
+def extract_mac_addr_from_string(string):
+    match = re.search(MAC_RE, string)
+    if match is None:
+        return ""
+    return match.group(0)
+
+
+### Check if valid MAC address
+def is_mac_addr(string):
+    return re.fullmatch(MAC_RE, string) is not None
+
+
+### Check if valid IPv4 address
+def is_ipv4(string):
+    return re.fullmatch(IPv4_RE, string) is not None
+
+
+### Check if valid IPv4 address or IPv4 prefix
+def is_ipv4_pfix(string):
+    return re.fullmatch(IPv4Pfix_RE, string) is not None
+
+
+### Check if valid IPv6 address
+def is_ipv6(string):
+    return re.fullmatch(IPv6_RE, string) is not None
+
+
+### Check if valid IPv6 address or IPv6 prefix
+def is_ipv6_pfix(string):
+    return re.fullmatch(IPv6Pfix_RE, string) is not None
+
+
+### Check if valid TCP/UDP port or ports range
+def is_tcp_udp_port(string):
+    return re.fullmatch(PORTS_RE, string) is not None
+
+
+### Cleanup URL
+def clean_url(url):
+    n = len(url)
+    if n:
+        if not url[n - 1] == "/":
+            url += "/"
+        if not url.startswith("http://") and not url.startswith("https://"):
+            url = "http://" + url
+    return url
+
+
+### Determine device IPv4 address info from IPv4 list, return the struct, none if nothing found
+def determine_ip(device):
+    if device is not None:
+        # Retrieve the list
+        ipv4_list = device.get("IPv4Address", [])
+
+        # If only one, return it
+        if len(ipv4_list) == 1:
+            return ipv4_list[0]
+
+        # Retrieve the reference IP address, but it can be an IPv6
+        ref_ip = device.get("IPAddress")
+        if ref_ip is not None:
+            if not is_ipv4(ref_ip):
+                ref_ip = None
+
+        # If there is no ref, return the first reachable address, otherwise the first
+        if ref_ip is None:
+            for i in ipv4_list:
+                if i.get("Status", "") == "reachable":
+                    return i
+            if len(ipv4_list) > 1:
+                return ipv4_list[0]
+
+        # If we have a ref, search for it in the list
+        else:
+            for i in ipv4_list:
+                if ref_ip == i.get("Address", ""):
+                    return i
+
+            # If nothing found, build artificially a struct
+            return {"Address": ref_ip,
+                    "Status": "",
+                    "Reserved": False}
+
+    return None
+
+
+### Send an email, returns true if successful
+def send_email(email_setup, subject, message):
+    # Create a text/plain message
+    m = EmailMessage()
+    m["From"] = email_setup["From"]
+    m["To"] = email_setup["To"]
+    m["Date"] = formatdate(localtime=True)
+    m["Subject"] = email_setup["Prefix"] + subject
+
+    # Message body
+    try:
+        m.set_content(message)
+    except Exception as e:
+        error(f"Cannot set email content. Error: {e}")
+        return False
+
+    # Create a session
+    s = None
+    try:
+        if email_setup["TLS"]:
+            s = smtplib.SMTP(email_setup["Server"], email_setup["Port"], timeout=SMTP_TIMEOUT)
+            s.starttls(context=ssl.create_default_context())
+        elif email_setup["SSL"]:
+            s = smtplib.SMTP_SSL(email_setup["Server"], email_setup["Port"], timeout=SMTP_TIMEOUT, context=ssl.create_default_context())
+        else:
+            s = smtplib.SMTP(email_setup["Server"], email_setup["Port"], timeout=SMTP_TIMEOUT)
+    except Exception as e:
+        error(f"Cannot setup email session. Error: {e}")
+        if s is not None:
+            try:
+                s.quit()
+            except Exception:
+                pass
+        return False
+
+    # Authenticate if necessary
+    if email_setup["Authentication"]:
+        try:
+            s.login(email_setup["User"], email_setup["Password"])
+        except Exception as e:
+            error(f"Authentication to SMTP server failed. Error: {e}")
+            try:
+                s.quit()
+            except Exception:
+                pass
+            return False
+
+    # Send the message
+    try:
+        s.send_message(m)
+    except Exception as e:
+        error(f"Cannot send email. Error: {e}")
+        try:
+            s.quit()
+        except Exception:
+            pass
+        return False
+
+    s.quit()
+    return True
+
+
+# ################################ Formatting Tools ################################
+
+### Format number of bytes
+def fmt_bytes(bytes_nb, suffix="B"):
+    for unit in ["", "K", "M", "G", "T", "P", "E", "Z"]:
+        if abs(bytes_nb) < 1024.0:
+            return f"{bytes_nb:3.1f} {unit}{suffix}"
+        bytes_nb /= 1024.0
+    return f"{bytes_nb:.1f} Y{suffix}"
+
+
+### Format boolean value
+def fmt_bool(bool_val):
+    if bool_val is None:
+        return ""
+    if bool_val:
+        return lx("True")
+    return lx("False")
+
+
+### Format integer value
+def fmt_int(int_val):
+    if int_val is None:
+        return ""
+    return str(int_val)
+
+
+### Format a string with capitalize
+def fmt_str_capitalize(string):
+    if string is None:
+        return ""
+    return string.capitalize()
+
+
+### Format a string in upper string
+def fmt_str_upper(string):
+    if string is None:
+        return ""
+    return string.upper()
+
+
+### Format time
+def fmt_time(seconds, no_zero=False):
+    if seconds is None:
+        return ""
+
+    days = seconds // (24 * 3600)
+    n = seconds % (24 * 3600)
+    hours = n // 3600
+    n %= 3600
+    minutes = n // 60
+    seconds = n % 60
+
+    if no_zero:
+        if days:
+            return f"{days:02d}d {hours:02d}h {minutes:02d}m {seconds:02d}s"
+        elif hours:
+            return f"{hours:02d}h {minutes:02d}m {seconds:02d}s"
+        elif minutes:
+            return f"{minutes:02d}m {seconds:02d}s"
+        elif seconds:
+            return f"{seconds:02d}s"
+        else:
+            return ""
+    else:
+        return f"{days:02d}d {hours:02d}h {minutes:02d}m {seconds:02d}s"
+
+
+### Format Livebox timestamps
+def livebox_timestamp(timestamp, utc=True):
+    try:
+        if utc:
+            return datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00")).replace(tzinfo = tz.tzutc()).astimezone(tz.tzlocal())
+        else:
+            return datetime.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+### Parse Livebox timestamp (UTC time by default)
+def fmt_livebox_timestamp(timestamp, utc=True):
+    if timestamp is None:
+        return ""
+    date_time = livebox_timestamp(timestamp, utc)
+    if date_time is None:
+        return ""
+    return date_time.strftime("%Y-%m-%d %H:%M:%S")
+
+


### PR DESCRIPTION
Before, many files in the `api` directory imported `app.LmTools` which has a hard dependency on Qt.  This meant that it was impossible to use _only_ the API without having Qt installed.

Now, all of the functions that used to be in `app.LmTools` that had no dependency on Qt are in `util.LmUtils`.  This allows the API to be used with no Qt dependency.

All files that depend on the moved functions have been updated.